### PR TITLE
When in dev environment assign all external api routes to go through vite server as a proxy.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,18 +1,7 @@
-// running in BE docker:
-// export const API_URL_BETA = `http://localhost:8080/FaBOnline/`;
-// export const API_URL_LIVE = `https://talishar.net/game/`;
-
-// running in old BE xampp docker:
-// export const API_URL_BETA = `http://localhost:41062/FaBOnline/`;
-// export const API_URL_LIVE = `https://talishar.net/game/`;
-
-// running on self-hoted (native) XAMPP:
-// export const API_URL_BETA = `http://localhost/FaBOnline/`;
-// export const API_URL_LIVE = `https://talishar.net/game/`;
-
 // running on beta/live on tinterwebs:
-export const API_URL_BETA = `https://beta.talishar.net/game/`;
-export const API_URL_LIVE = `https://talishar.net/game/`;
+export const API_URL_BETA = `/api/beta/`;
+export const API_URL_LIVE = `/api/prod/`;
+export const API_URL_DEV = `/api/dev`;
 
 export const DEFAULT_PLAYMAT = `Default`;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,19 @@
-// running on beta/live on tinterwebs:
-export const API_URL_BETA = `/api/beta/`;
-export const API_URL_LIVE = `/api/prod/`;
-export const API_URL_DEV = `/api/dev`;
+// For dev env use local proxy, on production connect directly to server.
+export const API_URL_BETA = import.meta.env.DEV
+  ? `/api/beta/`
+  : 'https://beta.talishar.net/game';
+export const API_URL_LIVE = import.meta.env.DEV
+  ? `/api/prod/`
+  : 'https://talishar.net/game';
+export const API_URL_DEV = import.meta.env.DEV
+  ? `/api/dev/`
+  : 'https://talishar.net/game';
 
 export const DEFAULT_PLAYMAT = `Default`;
 
 // How long in ms for a click versus 'long press'
 // TODO: make this user definable
 export const LONG_PRESS_TIMER = 250;
+
+export const GAME_LIMIT_PROD = 10000;
+export const GAME_LIMIT_BETA = 1000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ export const API_URL_BETA = import.meta.env.DEV
   ? `/api/beta/`
   : 'https://beta.talishar.net/game';
 export const API_URL_LIVE = import.meta.env.DEV
-  ? `/api/prod/`
+  ? `/api/live/`
   : 'https://talishar.net/game';
 export const API_URL_DEV = import.meta.env.DEV
   ? `/api/dev/`
@@ -15,5 +15,5 @@ export const DEFAULT_PLAYMAT = `Default`;
 // TODO: make this user definable
 export const LONG_PRESS_TIMER = 250;
 
-export const GAME_LIMIT_PROD = 10000;
+export const GAME_LIMIT_LIVE = 10000;
 export const GAME_LIMIT_BETA = 1000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,7 @@
 // For dev env use local proxy, on production connect directly to server.
+export const GAME_LIMIT_LIVE = 10000;
+export const GAME_LIMIT_BETA = 1000;
+
 export const API_URL_BETA = import.meta.env.DEV
   ? `/api/beta/`
   : 'https://beta.talishar.net/game';
@@ -9,11 +12,9 @@ export const API_URL_DEV = import.meta.env.DEV
   ? `/api/dev/`
   : 'https://talishar.net/game';
 
+// what playmat is the default
 export const DEFAULT_PLAYMAT = `Default`;
 
 // How long in ms for a click versus 'long press'
 // TODO: make this user definable
 export const LONG_PRESS_TIMER = 250;
-
-export const GAME_LIMIT_LIVE = 10000;
-export const GAME_LIMIT_BETA = 1000;

--- a/src/features/game/GameSlice.ts
+++ b/src/features/game/GameSlice.ts
@@ -7,7 +7,7 @@ import {
   API_URL_BETA,
   API_URL_LIVE,
   API_URL_DEV,
-  GAME_LIMIT_PROD,
+  GAME_LIMIT_LIVE,
   GAME_LIMIT_BETA
 } from '../../constants';
 import Button from '../Button';
@@ -17,7 +17,7 @@ export const nextTurn = createAsyncThunk(
   'game/nextTurn',
   async (params: GameInfo, { getState }) => {
     const queryURL =
-      params.gameID > GAME_LIMIT_PROD
+      params.gameID > GAME_LIMIT_LIVE
         ? `${API_URL_LIVE}GetNextTurn3.php?`
         : params.gameID > GAME_LIMIT_BETA
         ? `${API_URL_BETA}GetNextTurn3.php?`
@@ -72,7 +72,7 @@ export const playCard = createAsyncThunk(
     const gameInfo = game.gameInfo;
 
     const queryURL =
-      gameInfo.gameID > GAME_LIMIT_PROD
+      gameInfo.gameID > GAME_LIMIT_LIVE
         ? `${API_URL_LIVE}ProcessInput2.php?`
         : gameInfo.gameID > GAME_LIMIT_BETA
         ? `${API_URL_BETA}ProcessInput2.php?`
@@ -103,7 +103,7 @@ export const submitButton = createAsyncThunk(
   async (params: { button: Button }, { getState }) => {
     const { game } = getState() as { game: GameState };
     const queryURL =
-      game.gameInfo.gameID > GAME_LIMIT_PROD
+      game.gameInfo.gameID > GAME_LIMIT_LIVE
         ? `${API_URL_LIVE}ProcessInput2.php?`
         : game.gameInfo.gameID > GAME_LIMIT_BETA
         ? `${API_URL_BETA}ProcessInput2.php?`
@@ -133,7 +133,7 @@ export const submitMultiButton = createAsyncThunk(
   async (params: { mode?: number; extraParams: string }, { getState }) => {
     const { game } = getState() as { game: GameState };
     const queryURL =
-      game.gameInfo.gameID > GAME_LIMIT_PROD
+      game.gameInfo.gameID > GAME_LIMIT_LIVE
         ? `${API_URL_LIVE}ProcessInput2.php?`
         : game.gameInfo.gameID > GAME_LIMIT_BETA
         ? `${API_URL_BETA}ProcessInput2.php?`

--- a/src/features/game/GameSlice.ts
+++ b/src/features/game/GameSlice.ts
@@ -3,7 +3,13 @@ import ParseGameState from '../../app/ParseGameState';
 import InitialGameState from './InitialGameState';
 import GameInfo from '../GameInfo';
 import Card from '../Card';
-import { API_URL_BETA, API_URL_LIVE } from '../../constants';
+import {
+  API_URL_BETA,
+  API_URL_LIVE,
+  API_URL_DEV,
+  GAME_LIMIT_PROD,
+  GAME_LIMIT_BETA
+} from '../../constants';
 import Button from '../Button';
 import GameState from '../GameState';
 
@@ -11,9 +17,11 @@ export const nextTurn = createAsyncThunk(
   'game/nextTurn',
   async (params: GameInfo, { getState }) => {
     const queryURL =
-      params.gameID > 100000
+      params.gameID > GAME_LIMIT_PROD
         ? `${API_URL_LIVE}GetNextTurn3.php?`
-        : `${API_URL_BETA}GetNextTurn3.php?`;
+        : params.gameID > GAME_LIMIT_BETA
+        ? `${API_URL_BETA}GetNextTurn3.php?`
+        : `${API_URL_DEV}GetNextTurn3.php?`;
     const queryParams = new URLSearchParams({
       gameName: String(params.gameID),
       playerID: String(params.playerID),
@@ -64,9 +72,11 @@ export const playCard = createAsyncThunk(
     const gameInfo = game.gameInfo;
 
     const queryURL =
-      gameInfo.gameID > 100000
+      gameInfo.gameID > GAME_LIMIT_PROD
         ? `${API_URL_LIVE}ProcessInput2.php?`
-        : `${API_URL_BETA}ProcessInput2.php?`;
+        : gameInfo.gameID > GAME_LIMIT_BETA
+        ? `${API_URL_BETA}ProcessInput2.php?`
+        : `${API_URL_DEV}ProcessInput2.php?`;
     const queryParams = new URLSearchParams({
       gameName: String(gameInfo.gameID),
       playerID: String(gameInfo.playerID),
@@ -93,9 +103,11 @@ export const submitButton = createAsyncThunk(
   async (params: { button: Button }, { getState }) => {
     const { game } = getState() as { game: GameState };
     const queryURL =
-      game.gameInfo.gameID > 100000
+      game.gameInfo.gameID > GAME_LIMIT_PROD
         ? `${API_URL_LIVE}ProcessInput2.php?`
-        : `${API_URL_BETA}ProcessInput2.php?`;
+        : game.gameInfo.gameID > GAME_LIMIT_BETA
+        ? `${API_URL_BETA}ProcessInput2.php?`
+        : `${API_URL_DEV}ProcessInput2.php?`;
     const queryParams = new URLSearchParams({
       gameName: String(game.gameInfo.gameID),
       playerID: String(game.gameInfo.playerID),
@@ -121,9 +133,11 @@ export const submitMultiButton = createAsyncThunk(
   async (params: { mode?: number; extraParams: string }, { getState }) => {
     const { game } = getState() as { game: GameState };
     const queryURL =
-      game.gameInfo.gameID > 100000
+      game.gameInfo.gameID > GAME_LIMIT_PROD
         ? `${API_URL_LIVE}ProcessInput2.php?`
-        : `${API_URL_BETA}ProcessInput2.php?`;
+        : game.gameInfo.gameID > GAME_LIMIT_BETA
+        ? `${API_URL_BETA}ProcessInput2.php?`
+        : `${API_URL_DEV}ProcessInput2.php?`;
     const queryParams = new URLSearchParams({
       gameName: String(game.gameInfo.gameID),
       playerID: String(game.gameInfo.playerID),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,11 +32,11 @@ export default defineConfig({
         //   });
         // }
       },
-      '/api/prod': {
+      '/api/live': {
         target: 'https://talishar.net/game',
         changeOrigin: true,
         secure: false,
-        rewrite: (path) => path.replace(/api\/prod\//, '')
+        rewrite: (path) => path.replace(/api\/live\//, '')
       },
       '/api/dev': {
         target: 'http://localhost:8080/FaBOnline',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,8 +14,8 @@ export default defineConfig({
         target: 'https://beta.talishar.net/game',
         changeOrigin: true,
         secure: false,
-        ws: true,
-        rewrite: (path) => path.replace(/api\/beta/, '')
+        rewrite: (path) => path.replace(/api\/beta\//, '')
+        // ** FOR DEBUGGING THE PROXY **
         // configure: (proxy, _options) => {
         //   proxy.on('error', (err, _req, _res) => {
         //     console.log('proxy error', err);
@@ -36,15 +36,13 @@ export default defineConfig({
         target: 'https://talishar.net/game',
         changeOrigin: true,
         secure: false,
-        ws: true,
-        rewrite: (path) => path.replace(/api\/prod/, '')
+        rewrite: (path) => path.replace(/api\/prod\//, '')
       },
       '/api/dev': {
         target: 'http://localhost:8080/FaBOnline',
         changeOrigin: true,
         secure: false,
-        ws: true,
-        rewrite: (path) => path.replace(/api\/dev/, '')
+        rewrite: (path) => path.replace(/api\/dev\//, '')
       }
     }
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,5 +7,45 @@ import svgrPlugin from 'vite-plugin-svgr';
 export default defineConfig({
   base: './',
   build: { outDir: './build' },
-  plugins: [react(), viteTsconfigPaths(), svgrPlugin()]
+  plugins: [react(), viteTsconfigPaths(), svgrPlugin()],
+  server: {
+    proxy: {
+      '/api/beta': {
+        target: 'https://beta.talishar.net/game',
+        changeOrigin: true,
+        secure: false,
+        ws: true,
+        rewrite: (path) => path.replace(/api\/beta/, '')
+        // configure: (proxy, _options) => {
+        //   proxy.on('error', (err, _req, _res) => {
+        //     console.log('proxy error', err);
+        //   });
+        //   proxy.on('proxyReq', (proxyReq, req, _res) => {
+        //     console.log('Sending Request to the Target:', req.method, req.url);
+        //   });
+        //   proxy.on('proxyRes', (proxyRes, req, _res) => {
+        //     console.log(
+        //       'Received Response from the Target:',
+        //       proxyRes.statusCode,
+        //       req.url
+        //     );
+        //   });
+        // }
+      },
+      '/api/prod': {
+        target: 'https://talishar.net/game',
+        changeOrigin: true,
+        secure: false,
+        ws: true,
+        rewrite: (path) => path.replace(/api\/prod/, '')
+      },
+      '/api/dev': {
+        target: 'http://localhost:8080/FaBOnline',
+        changeOrigin: true,
+        secure: false,
+        ws: true,
+        rewrite: (path) => path.replace(/api\/dev/, '')
+      }
+    }
+  }
 });


### PR DESCRIPTION
Closes issue #15 - when in dev environment it will use vite as a proxy, so no more CORS issues (hopefully).

When in production it will call the env as normal.

We probably need a better way to determine if we're calling beta server or production server.