### PR TITLE
Enable OptionsMenu toggle from MenuButton

### DIFF
--- a/src/routes/game/components/elements/menu/Menu.test.tsx
+++ b/src/routes/game/components/elements/menu/Menu.test.tsx
@@ -3,13 +3,20 @@ import { Provider } from 'react-redux';
 import { store } from 'app/Store';
 import { createRoot } from 'react-dom/client';
 import Menu from './Menu';
+import { renderWithProviders } from 'utils/TestUtils';
+import { screen } from '@testing-library/react';
 
-it('renders without crashin', () => {
-  const div = document.createElement('div');
-  const root = createRoot(div);
-  root.render(
-    <Provider store={store}>
-      <Menu />
-    </Provider>
-  );
-});
+describe('menu', () => {
+
+  beforeEach(() => {
+    renderWithProviders(<Menu />);
+  })
+
+  it('renders the buttons properly', () => {
+    expect(screen.getByTitle('options menu button')).toBeDefined();
+    expect(screen.getByTitle('fullscreen button')).toBeDefined();
+    expect(screen.getByTitle('undo button')).toBeDefined();
+
+  });
+  
+})

--- a/src/routes/game/components/elements/menu/Menu.test.tsx
+++ b/src/routes/game/components/elements/menu/Menu.test.tsx
@@ -7,16 +7,13 @@ import { renderWithProviders } from 'utils/TestUtils';
 import { screen } from '@testing-library/react';
 
 describe('menu', () => {
-
   beforeEach(() => {
     renderWithProviders(<Menu />);
-  })
+  });
 
   it('renders the buttons properly', () => {
     expect(screen.getByTitle('options menu button')).toBeDefined();
     expect(screen.getByTitle('fullscreen button')).toBeDefined();
     expect(screen.getByTitle('undo button')).toBeDefined();
-
   });
-  
-})
+});

--- a/src/routes/game/components/elements/menu/Menu.tsx
+++ b/src/routes/game/components/elements/menu/Menu.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import screenfull from 'screenfull';
-import { useAppDispatch } from 'app/Hooks';
-import { openOptionsMenu, submitButton } from 'features/game/GameSlice';
+import { useAppDispatch, useAppSelector } from 'app/Hooks';
+import { openOptionsMenu, closeOptionsMenu, submitButton } from 'features/game/GameSlice';
 import { FaUndo } from 'react-icons/fa';
 import { GiExpand, GiHamburgerMenu } from 'react-icons/gi';
 import styles from './Menu.module.css';
 import { PROCESS_INPUT } from 'constants';
+import { RootState } from 'app/Store';
 
 function MenuButton() {
+  const optionsMenu = useAppSelector(
+    (state: RootState) => state.game.optionsMenu
+  );
   const dispatch = useAppDispatch();
   const toggleMenu = () => {
-    dispatch(openOptionsMenu());
+    if (optionsMenu?.active) return dispatch(closeOptionsMenu());
+    return dispatch(openOptionsMenu());
   };
 
   return (

--- a/src/routes/game/components/elements/menu/Menu.tsx
+++ b/src/routes/game/components/elements/menu/Menu.tsx
@@ -22,8 +22,8 @@ function MenuButton() {
     <div>
       <button
         className={styles.btn}
-        aria-label="Open main menu"
-        title="options menu"
+        aria-label="Toggle main menu"
+        title="options menu button"
         onClick={() => toggleMenu()}
       >
         <GiHamburgerMenu aria-hidden="true" fontSize={'1.5rem'} />
@@ -42,6 +42,7 @@ function FullScreenButton() {
       <button
         className={styles.btn}
         aria-label="Full Screen"
+        title="fullscreen button"
         onClick={() => toggleFullScreen()}
       >
         <GiExpand aria-hidden="true" fontSize={'1.5rem'} />
@@ -57,7 +58,12 @@ function UndoButton() {
   };
   return (
     <div>
-      <button className={styles.btn} aria-label="Undo" onClick={clickUndo}>
+      <button
+        className={styles.btn}
+        aria-label="Undo"
+        onClick={clickUndo}
+        title="undo button"
+      >
         <FaUndo aria-hidden="true" fontSize={'1.5rem'} />
       </button>
     </div>

--- a/src/routes/game/components/elements/menu/Menu.tsx
+++ b/src/routes/game/components/elements/menu/Menu.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import screenfull from 'screenfull';
 import { useAppDispatch, useAppSelector } from 'app/Hooks';
-import { openOptionsMenu, closeOptionsMenu, submitButton } from 'features/game/GameSlice';
+import {
+  openOptionsMenu,
+  closeOptionsMenu,
+  submitButton
+} from 'features/game/GameSlice';
 import { FaUndo } from 'react-icons/fa';
 import { GiExpand, GiHamburgerMenu } from 'react-icons/gi';
 import styles from './Menu.module.css';


### PR DESCRIPTION
Enabled toggle functionality for the 'active' state of the OptionsMenu within the MenuButton component. 
This allows the OptionsMenu to be opened and closed by clicking the MenuButton.
![GIF 25-01-2023 03-50-23](https://user-images.githubusercontent.com/5968740/214498567-05aec051-a66d-4212-8f98-9b5eb152c8ee.gif)

