### PR TITLE
Add useShortcut hook to handle keyboard input logic

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -90,5 +90,5 @@ export const PROCESS_INPUT = {
 // Default shortcut inputs
 export const DEFAULT_SHORTCUTS = {
   TOGGLE_OPTIONS_MENU: ['m', 'M'],
-  PASS_TURN: [' '],
+  PASS_TURN: [' ']
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,6 +89,6 @@ export const PROCESS_INPUT = {
 
 // Default shortcut inputs
 export const DEFAULT_SHORTCUTS = {
-  TOGGLE_OPTIONS_MENU: ['m', 'M'],
-  PASS_TURN: [' ']
+  TOGGLE_OPTIONS_MENU: 'KeyM',
+  PASS_TURN: 'Space'
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,3 +86,9 @@ export const PROCESS_INPUT = {
   ROGUELIKE_RESUME_ADVENTURE: 100011,
   CREATE_REPLAY: 100012
 };
+
+// Default shortcut inputs
+export const DEFAULT_SHORTCUTS = {
+  TOGGLE_OPTIONS_MENU: ['m', 'M'],
+  PASS_TURN: [' '],
+};

--- a/src/hooks/useShortcut.tsx
+++ b/src/hooks/useShortcut.tsx
@@ -1,11 +1,11 @@
-import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 
 const useShortcut = (keys: Array<String>, callback: Function) => {
   // callback ref pattern
   const callbackRef = useRef(callback);
   useLayoutEffect(() => {
     callbackRef.current = callback;
-  })
+  });
 
   const handleKeyPress = useCallback(
     (event: KeyboardEvent) => {
@@ -17,11 +17,10 @@ const useShortcut = (keys: Array<String>, callback: Function) => {
   );
 
   useEffect(() => {
-    document.addEventListener("keydown", handleKeyPress);
+    document.addEventListener('keydown', handleKeyPress);
 
-    return () =>
-      document.removeEventListener("keydown", handleKeyPress);
+    return () => document.removeEventListener('keydown', handleKeyPress);
   }, [handleKeyPress]);
-}
+};
 
 export default useShortcut;

--- a/src/hooks/useShortcut.tsx
+++ b/src/hooks/useShortcut.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 
-const useShortcut = (keys: Array<String>, callback: Function) => {
+const useShortcut = (keyCode: String, callback: Function) => {
   // callback ref pattern
   const callbackRef = useRef(callback);
   useLayoutEffect(() => {
@@ -9,11 +9,11 @@ const useShortcut = (keys: Array<String>, callback: Function) => {
 
   const handleKeyPress = useCallback(
     (event: KeyboardEvent) => {
-      if (keys.some((key: String) => event.key === key)) {
+      if (event.code === keyCode) {
         callbackRef.current(event);
       }
     },
-    [keys]
+    [keyCode]
   );
 
   useEffect(() => {

--- a/src/hooks/useShortcut.tsx
+++ b/src/hooks/useShortcut.tsx
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+
+const useShortcut = (keys: Array<String>, callback: Function) => {
+  // callback ref pattern
+  const callbackRef = useRef(callback);
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  })
+
+  const handleKeyPress = useCallback(
+    (event: KeyboardEvent) => {
+      if (keys.some((key: String) => event.key === key)) {
+        callbackRef.current(event);
+      }
+    },
+    [keys]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyPress);
+
+    return () =>
+      document.removeEventListener("keydown", handleKeyPress);
+  }, [handleKeyPress]);
+}
+
+export default useShortcut;

--- a/src/routes/game/components/elements/menu/Menu.tsx
+++ b/src/routes/game/components/elements/menu/Menu.tsx
@@ -9,8 +9,9 @@ import {
 import { FaUndo } from 'react-icons/fa';
 import { GiExpand, GiHamburgerMenu } from 'react-icons/gi';
 import styles from './Menu.module.css';
-import { PROCESS_INPUT } from 'constants';
+import { DEFAULT_SHORTCUTS, PROCESS_INPUT } from 'constants';
 import { RootState } from 'app/Store';
+import useShortcut from 'hooks/useShortcut';
 
 function MenuButton() {
   const optionsMenu = useAppSelector(
@@ -21,6 +22,8 @@ function MenuButton() {
     if (optionsMenu?.active) return dispatch(closeOptionsMenu());
     return dispatch(openOptionsMenu());
   };
+  
+  useShortcut(DEFAULT_SHORTCUTS.TOGGLE_OPTIONS_MENU, toggleMenu);
 
   return (
     <div>

--- a/src/routes/game/components/elements/menu/Menu.tsx
+++ b/src/routes/game/components/elements/menu/Menu.tsx
@@ -22,7 +22,7 @@ function MenuButton() {
     if (optionsMenu?.active) return dispatch(closeOptionsMenu());
     return dispatch(openOptionsMenu());
   };
-  
+
   useShortcut(DEFAULT_SHORTCUTS.TOGGLE_OPTIONS_MENU, toggleMenu);
 
   return (

--- a/src/routes/game/components/elements/passTurnDisplay/PassTurnDisplay.tsx
+++ b/src/routes/game/components/elements/passTurnDisplay/PassTurnDisplay.tsx
@@ -17,7 +17,7 @@ export default function PassTurnDisplay() {
     dispatch(submitButton({ button: { mode: PROCESS_INPUT.PASS } }));
   };
 
-  useShortcut(DEFAULT_SHORTCUTS.PASS_TURN, onPassTurn)
+  useShortcut(DEFAULT_SHORTCUTS.PASS_TURN, onPassTurn);
 
   if (canPassPhase === undefined) {
     return <div className={styles.passTurnDisplay}></div>;

--- a/src/routes/game/components/elements/passTurnDisplay/PassTurnDisplay.tsx
+++ b/src/routes/game/components/elements/passTurnDisplay/PassTurnDisplay.tsx
@@ -3,7 +3,8 @@ import { playCard, submitButton } from 'features/game/GameSlice';
 import { useAppSelector, useAppDispatch } from 'app/Hooks';
 import { RootState } from 'app/Store';
 import styles from './PassTurnDisplay.module.css';
-import { PROCESS_INPUT } from 'constants';
+import { DEFAULT_SHORTCUTS, PROCESS_INPUT } from 'constants';
+import useShortcut from 'hooks/useShortcut';
 
 export default function PassTurnDisplay() {
   const canPassPhase = useAppSelector(
@@ -16,18 +17,7 @@ export default function PassTurnDisplay() {
     dispatch(submitButton({ button: { mode: PROCESS_INPUT.PASS } }));
   };
 
-  const pressKey = (e: KeyboardEvent) => {
-    if (e.key == ' ') {
-      onPassTurn();
-    }
-  };
-
-  // TODO: Migrate the key listeners to a separate component
-  // component can have customisable keys maybe
-  useEffect(() => {
-    document.addEventListener('keydown', pressKey, false);
-    // return document.removeEventListener('keydown', pressKey, true);
-  }, []);
+  useShortcut(DEFAULT_SHORTCUTS.PASS_TURN, onPassTurn)
 
   if (canPassPhase === undefined) {
     return <div className={styles.passTurnDisplay}></div>;


### PR DESCRIPTION
Added **useShortcut** hook for handling keyboard input logic.

This PR try to provide a solution for https://github.com/Talishar/Talishar-FE/issues/32 by adding a hook that separates shortcut logic from UI logic.

The `useShortcut` hook provides a way for components to listen for specific keyboard inputs and respond accordingly. This allows for a more efficient way of handling keyboard events, instead of adding event listeners to multiple elements in the component. The hook's implementation is heavily inspired by [this article](https://devtrium.com/posts/how-keyboard-shortcut).

This PR also implements the new hook on `Menu.tsx` and `PassTurnDisplay.tsx`.
