### PR TITLE
Add env for non-docker installs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,5 @@
+# if you've got different settings than from docker
+
+VITE_DEV_URL="localhost"
+VITE_DEV_PORT="8080"
+VITE_DEV_DIRECTORY="game"

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ yarn-error.log*
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+.env

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,58 +1,72 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 import svgrPlugin from 'vite-plugin-svgr';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: './',
-  build: { outDir: './build' },
-  plugins: [react(), viteTsconfigPaths(), svgrPlugin()],
-  server: {
-    proxy: {
-      '/api/beta': {
-        target: 'https://beta.talishar.net/game',
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/api\/beta\//, '')
-        // ** FOR DEBUGGING THE PROXY **
-        // configure: (proxy, _options) => {
-        //   proxy.on('error', (err, _req, _res) => {
-        //     console.log('proxy error', err);
-        //   });
-        //   proxy.on('proxyReq', (proxyReq, req, _res) => {
-        //     console.log('Sending Request to the Target:', req.method, req.url);
-        //   });
-        //   proxy.on('proxyRes', (proxyRes, req, _res) => {
-        //     console.log(
-        //       'Received Response from the Target:',
-        //       proxyRes.statusCode,
-        //       req.url
-        //     );
-        //   });
-        // }
-      },
-      '/api/live': {
-        target: 'https://talishar.net/game',
-        changeOrigin: true,
-        secure: true,
-        rewrite: (path) => path.replace(/api\/live\//, '')
-      },
-      '/api/dev': {
-        target: 'http://localhost:8080/game',
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/api\/dev\//, '')
+export default ({ mode }) => {
+  process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
+
+  const devURL = !!process.env.VITE_DEV_URL
+    ? process.env.VITE_DEV_URL
+    : 'localhost';
+  const devPort = !!process.env.VITE_DEV_PORT
+    ? process.env.VITE_DEV_PORT
+    : '8080';
+  const devDirectory = !!process.env.VITE_DEV_DIRECTORY
+    ? process.env.VITE_DEV_PORT
+    : 'game';
+
+  return defineConfig({
+    base: './',
+    build: { outDir: './build' },
+    plugins: [react(), viteTsconfigPaths(), svgrPlugin()],
+    server: {
+      proxy: {
+        '/api/beta': {
+          target: 'https://beta.talishar.net/game',
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path) => path.replace(/api\/beta\//, '')
+          // ** FOR DEBUGGING THE PROXY **
+          // configure: (proxy, _options) => {
+          //   proxy.on('error', (err, _req, _res) => {
+          //     console.log('proxy error', err);
+          //   });
+          //   proxy.on('proxyReq', (proxyReq, req, _res) => {
+          //     console.log('Sending Request to the Target:', req.method, req.url);
+          //   });
+          //   proxy.on('proxyRes', (proxyRes, req, _res) => {
+          //     console.log(
+          //       'Received Response from the Target:',
+          //       proxyRes.statusCode,
+          //       req.url
+          //     );
+          //   });
+          // }
+        },
+        '/api/live': {
+          target: 'https://talishar.net/game',
+          changeOrigin: true,
+          secure: true,
+          rewrite: (path) => path.replace(/api\/live\//, '')
+        },
+        '/api/dev': {
+          target: `https://${devURL}:${devPort}/${devDirectory}`,
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path) => path.replace(/api\/dev\//, '')
+        }
       }
-    }
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    coverage: {
-      provider: 'c8'
     },
-    setupFiles: './src/setupTests.ts'
-  }
-});
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      coverage: {
+        provider: 'c8'
+      },
+      setupFiles: './src/setupTests.ts'
+    }
+  });
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,7 +53,7 @@ export default ({ mode }) => {
           rewrite: (path) => path.replace(/api\/live\//, '')
         },
         '/api/dev': {
-          target: `https://${devURL}:${devPort}/${devDirectory}`,
+          target: `http://${devURL}:${devPort}/${devDirectory}`,
           changeOrigin: true,
           secure: false,
           rewrite: (path) => path.replace(/api\/dev\//, '')


### PR DESCRIPTION
People using XAMPP for their backend development can't get React FE working with it, because ports and game directories etc are all different and causing issues.

We read a .env and update the routes in the vite proxy server config to help with that. So if there is a custom different install, it can be configured in the .env file so everybody is happy.