### PR TITLE
Fix non-playable banish cards showing up in your banish hand

### DIFF
--- a/src/routes/game/components/zones/playerHand/PlayerHand.tsx
+++ b/src/routes/game/components/zones/playerHand/PlayerHand.tsx
@@ -29,7 +29,7 @@ export default function PlayerHand() {
   );
   const playableBanishedCards = useAppSelector((state: RootState) => {
     return state.game.playerOne.Banish?.filter(
-      (card) => card.borderColor != '0' && card.borderColor != null
+      (card) => card.action != null && card.action != "0"
     );
   }, shallowEqual);
   const playableGraveyardCards = useAppSelector(


### PR DESCRIPTION
We were looking at border color to see if it's playable, instead of action. Action is what denotes if it's playable or not.