### PR TITLE
Remove padding around log out button to keep navbar height consistant

### DIFF
--- a/src/components/header/Header.module.css
+++ b/src/components/header/Header.module.css
@@ -1,3 +1,11 @@
 .navBar {
   top: 0px;
 }
+
+.logoutButton {
+  padding: 0 var(--nav-link-spacing-horizontal);
+}
+
+.logoutButton button {
+  padding: .25rem var(--nav-link-spacing-horizontal);
+}


### PR DESCRIPTION
I know this isn't the highest priority issue with the big switchover to the React clients, but it was bugging me and I knew how to fix it quickly so here is a tiny fix as I dip my toes into the water of contribution.

On the home screen in the navigation bar, the default styling of the logout button is larger then the other links, this causes the navbar to grow in size one a user is logged in. Since page restate is at a premium with other padding and font sizes, I adjusted the vertical padding around and inside of the button to keep the navigation bar a consistent height 
Before:
![Screenshot 2023-04-02 102626](https://user-images.githubusercontent.com/8871975/229362978-df5403b0-c3e9-4aa7-894e-805e3f00bfd6.png)
After:
![login button fix after](https://user-images.githubusercontent.com/8871975/229362985-020daaf4-fdad-4023-9033-61f554818679.png)
