### PR TITLE
Add higher specificity to css selector

### DIFF
--- a/src/routes/game/components/elements/currentAttack/CurrentAttack.module.css
+++ b/src/routes/game/components/elements/currentAttack/CurrentAttack.module.css
@@ -22,7 +22,7 @@
   pointer-events: none;
 }
 
-.icon {
+.icon.icon {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -37,10 +37,6 @@
   margin: 0.25em;
   pointer-events: auto;
   user-select: none;
-}
-
-.icon .icon {
-  border-bottom: var(--primary) solid 1px;
 }
 
 .cardContainer {


### PR DESCRIPTION
Issue was due to picocss having a higher level of specificity and a typo of `.icon .icon` vs `.icon.icon` however we can just update the specificity of the other css selector and not need to override the bottom boarder specifically which I think is cleaner

![image](https://user-images.githubusercontent.com/8871975/229383228-64060079-e970-4dc8-a8b6-3525ddda0e92.png)
