### PR TITLE
add local storage of auth keys

### DIFF
--- a/src/utils/LocalKeyManagement.ts
+++ b/src/utils/LocalKeyManagement.ts
@@ -1,0 +1,20 @@
+export const saveGameAuthKey = (gameId: number,authKey:string): void => {
+  sessionStorage.setItem(String(gameId),authKey)
+}
+
+export const loadGameAuthKey = (gameId: number): string => {
+  const localValue = sessionStorage.getItem(String(gameId))
+  if(!localValue){
+    console.error("Attempted to access an authKey of a game that does not exist, game:" + gameId)
+  }
+  return localValue || ""
+}
+
+export const deleteGameAuthKey = (gameId: number): void => {
+  const valueExists = sessionStorage.getItem(String(gameId));
+  if(!valueExists){
+    console.error("Attempted to delete a authKey of a game that does not exist, game", + gameId)
+    return
+  }
+  sessionStorage.removeItem(String(gameId))
+}


### PR DESCRIPTION
Refresh issues were due to the fact that the Auth value is no longer in the query params so on reload when we blow away state our request to nextTurn fails because we don't send an authKey with the request.

I has added the storage of the authKey into the session storage. There are Pros and Cons to this so happy to have a discussion of sessionStorage vs localStorage

|                 | Pros                                                                                                            | Cons                                                                                                                                                                                 |
|-----------------|-----------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Local Storage   | Key persists allowing for retrieval across tabs and sessions                                                    | We will cause a memory leak if we store the data as Game:key pairs as the data doesn't expire.  If a user just closes the tab we don't know to delete the data so it will just exist |
| Session Storage | Key is Auto Deleted when the tab closes We can support multiple auth keys at once if people want to multi queue | Key only exists in the tab so they will not be able to copy and past a game link and have it load on the second page                                                                 |

