### PR TITLE
Move attack overlays into CounterOverlays. 

### DIFF
--- a/src/routes/game/components/elements/cardDisplay/CardDisplay.tsx
+++ b/src/routes/game/components/elements/cardDisplay/CardDisplay.tsx
@@ -6,6 +6,8 @@ import classNames from 'classnames';
 import CountersOverlay from '../countersOverlay/CountersOverlay';
 import CardImage from '../cardImage/CardImage';
 import CardPopUp from '../cardPopUp/CardPopUp';
+import { ActiveCardCounterOverlay } from '../countersOverlay/components/ActiveChainCounters';
+import CombatChainLink from 'features/CombatChainLink';
 
 export interface CardProp {
   makeMeBigger?: boolean;
@@ -14,11 +16,11 @@ export interface CardProp {
   preventUseOnClick?: boolean;
   useCardMode?: number;
   card?: Card;
+  activeCombatChain?: CombatChainLink;
 }
 
 export const CardDisplay = (prop: CardProp) => {
-  const { card, preventUseOnClick } = prop;
-  const { num } = prop;
+  const { card, preventUseOnClick, activeCombatChain, num } = prop;
   const dispatch = useAppDispatch();
 
   if (card == null || card.cardNumber === '') {
@@ -74,7 +76,7 @@ export const CardDisplay = (prop: CardProp) => {
       {(card.isBroken || card.onChain || card.isFrozen) && (
         <div className={equipStatus}></div>
       )}
-      <CountersOverlay {...card} num={num} />
+      <CountersOverlay {...card} num={num} activeCombatChain={activeCombatChain}/>
     </CardPopUp>
   );
 };

--- a/src/routes/game/components/elements/countersOverlay/CountersOverlay.module.css
+++ b/src/routes/game/components/elements/countersOverlay/CountersOverlay.module.css
@@ -19,6 +19,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-wrap: wrap;
   left: 0px;
   top: 0px;
   right: 0px;
@@ -112,6 +113,10 @@
     -1px -1px 0 #000;
 }
 
+[data-tooltip]::before{
+  text-shadow: none;
+}
+
 .aimCounter {
   border-radius: 100%;
   height: 2em;
@@ -119,6 +124,7 @@
   background-image: url('../../../../../img/symbols/symbol-aim.png');
   background-position: center;
   background-size: contain;
+  border: none;
 }
 
 .facing {
@@ -138,4 +144,33 @@
 
 .text {
   color: black;
+}
+
+.floatCover {
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-content: center;
+  flex-wrap: wrap;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.icon.icon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  border: var(--primary) solid 1px;
+  color: var(--white);
+  border-radius: 5px;
+  width: 1.5em;
+  height: 1.5em;
+  font-size: 1.75em;
+  padding: 2px;
+  margin: 0.25em;
+  pointer-events: auto;
+  user-select: none;
 }

--- a/src/routes/game/components/elements/countersOverlay/CountersOverlay.tsx
+++ b/src/routes/game/components/elements/countersOverlay/CountersOverlay.tsx
@@ -3,10 +3,14 @@ import { Card } from 'features/Card';
 import styles from './CountersOverlay.module.css';
 import GemSlider from '../gemSlider/GemSlider';
 import classNames from 'classnames';
+import { ActiveCardCounterOverlay } from './components/ActiveChainCounters';
+import CombatChainLink from 'features/CombatChainLink';
+import { ContinuousCounters } from './components/ContinuousCounters';
 
 export interface CountersProp extends Card {
   num?: number;
   numDescription?: string;
+  activeCombatChain?: CombatChainLink;
 }
 
 export const CountersOverlay = ({
@@ -17,7 +21,8 @@ export const CountersOverlay = ({
   num,
   numDescription,
   facing,
-  zone
+  zone,
+  activeCombatChain
 }: CountersProp) => {
   const includedCounters = [
     'defence',
@@ -40,49 +45,8 @@ export const CountersOverlay = ({
 
   return (
     <div className={styles.countersCover}>
-      {!!Number(countersMap?.defence) && (
-        <div
-          className={styles.defCounter}
-          title={`${countersMap?.defence} defence counter(s)`}
-        >
-          <div>{countersMap?.defence}</div>
-        </div>
-      )}
-      {!!Number(countersMap?.steam) && (
-        <div
-          className={styles.steamCounter}
-          title={`${countersMap?.steam} steam counter(s)`}
-        >
-          <div>{countersMap?.steam}</div>
-        </div>
-      )}
-      {!!Number(countersMap?.life) && (
-        <div
-          className={styles.lifeCounter}
-          title={`${countersMap?.life} life counter(s)`}
-        >
-          <div>{countersMap?.life}</div>
-        </div>
-      )}
-      {!!Number(countersMap?.attack) && (
-        <div
-          className={styles.attackCounter}
-          title={`${countersMap?.attack} attack counter(s)`}
-        >
-          <div>{countersMap?.attack}</div>
-        </div>
-      )}
-      {!!Number(countersMap?.energy) && (
-        <div
-          className={styles.number}
-          title={`${countersMap?.energy} energy counter(s)`}
-        >
-          <div className={styles.text}>{countersMap?.energy}</div>
-        </div>
-      )}
-      {!!Number(countersMap?.aim) && (
-        <div className={styles.aimCounter} title={`aim counter`}></div>
-      )}
+      {countersMap && <ContinuousCounters countersMap={countersMap} />}
+      {activeCombatChain && <ActiveCardCounterOverlay activeCombatChain={activeCombatChain} />}
       {!!numTotal && (
         <div
           className={styles.number}

--- a/src/routes/game/components/elements/countersOverlay/components/ActiveChainCounters.tsx
+++ b/src/routes/game/components/elements/countersOverlay/components/ActiveChainCounters.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import CombatChainLink from "features/CombatChainLink"
+import styles from '../CountersOverlay.module.css';
+import { GiCycle, GiElectric, GiShield, GiZigzagLeaf } from 'react-icons/gi';
+import { BiBullseye } from 'react-icons/bi';
+type Props = {
+  activeCombatChain?: CombatChainLink
+}
+export const ActiveCardCounterOverlay = (props: Props) => {
+  const {
+    activeCombatChain
+  } = props;
+
+  if(!activeCombatChain){ return null};
+  return (
+    <>
+      {activeCombatChain.goAgain ? (
+        <div className={styles.icon} data-tooltip="Go Again">
+          <GiCycle />
+        </div>
+      ) : null}
+      {activeCombatChain.dominate ? (
+        <div className={styles.icon} data-tooltip="Dominate">
+          <BiBullseye />
+        </div>
+      ) : null}
+      {activeCombatChain.overpower ? (
+        <div className={styles.icon} data-tooltip="Overpower">
+          <GiElectric />
+        </div>
+      ) : null}
+      {activeCombatChain.fused ? (
+        <div className={styles.icon} data-tooltip="Fused">
+          <GiZigzagLeaf />
+        </div>
+      ) : null}
+      {activeCombatChain.damagePrevention ? (
+        <div
+          className={styles.icon}
+          data-tooltip={`${activeCombatChain.damagePrevention} Damage Prevention`}
+        >
+          <GiShield />
+          {activeCombatChain.damagePrevention}
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/src/routes/game/components/elements/countersOverlay/components/ContinuousCounters.tsx
+++ b/src/routes/game/components/elements/countersOverlay/components/ContinuousCounters.tsx
@@ -1,0 +1,79 @@
+import classNames from 'classnames';
+import styles from '../CountersOverlay.module.css';
+
+type Props = {
+  countersMap: {[key:string]: number}
+}
+
+const includedCounters = [
+  'defence',
+  'steam',
+  'life',
+  'attack',
+  'energy',
+  'aim'
+];
+
+const toTooltipString = (type: string, value: number) => `${value>1 ? value : '' } ${type} counter${value>1 ? 's' : ''}`
+export const ContinuousCounters = (props: Props) => {
+  const {
+    countersMap,
+  } = props;
+
+  return (
+    <>
+    {!!Number(countersMap?.defence) && (
+        <div
+          className={styles.defCounter}
+          title={`${countersMap?.defence} defence counter(s)`}
+          data-tooltip={toTooltipString('Defense', countersMap?.defence)}
+        >
+          <div>{countersMap?.defence}</div>
+        </div>
+      )}
+      {!!Number(countersMap?.steam) && (
+        <div
+          className={styles.steamCounter}
+          title={`${countersMap?.steam} steam counter(s)`}
+          data-tooltip={toTooltipString('Steam', countersMap?.steam)}
+        >
+          <div>{countersMap?.steam}</div>
+        </div>
+      )}
+      {!!Number(countersMap?.life) && (
+        <div
+          className={styles.lifeCounter}
+          title={`${countersMap?.life} life counter(s)`}
+          data-tooltip={toTooltipString('Life', countersMap?.life)}
+        >
+          <div>{countersMap?.life}</div>
+        </div>
+      )}
+      {!!Number(countersMap?.attack) && (
+        <div
+          className={styles.attackCounter}
+          title={`${countersMap?.attack} attack counter(s)`}
+          data-tooltip={toTooltipString('Attack', countersMap?.attack)}
+        >
+          <div>{countersMap?.attack}</div>
+        </div>
+      )}
+      {!!Number(countersMap?.energy) && (
+        <div
+          className={styles.number}
+          title={`${countersMap?.energy} energy counter(s)`}
+          data-tooltip={toTooltipString('Energy', countersMap?.energy)}
+        >
+          <div className={styles.text}>{countersMap?.energy}</div>
+        </div>
+      )}
+      {!!Number(countersMap?.aim) && (
+        <div 
+          className={classNames(styles.aimCounter, styles.icon)}
+          title={`aim counter`}
+          data-tooltip={toTooltipString('Aim', countersMap?.aim)}
+        />
+      )}
+    </>
+  )
+}

--- a/src/routes/game/components/elements/currentAttack/CurrentAttack.tsx
+++ b/src/routes/game/components/elements/currentAttack/CurrentAttack.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { RootState } from 'app/Store';
-import { BiBullseye, BiTargetLock } from 'react-icons/bi';
-import { GiZigzagLeaf, GiElectric, GiCycle, GiShield } from 'react-icons/gi';
+import { BiTargetLock } from 'react-icons/bi';
 import styles from './CurrentAttack.module.css';
 import attackSymbol from '../../../../../img/symbols/symbol-attack.png';
 import defSymbol from '../../../../../img/symbols/symbol-defence.png';
@@ -59,38 +58,7 @@ export default function CurrentAttack() {
         ) : null}
       </div>
       <div className={styles.attack}>
-        <CardDisplay card={attCard} />
-        <div className={styles.floatCover}>
-          {activeCombatChain.goAgain ? (
-            <div className={styles.icon} data-tooltip="Go Again">
-              <GiCycle />
-            </div>
-          ) : null}
-          {activeCombatChain.dominate ? (
-            <div className={styles.icon} data-tooltip="Dominate">
-              <BiBullseye />
-            </div>
-          ) : null}
-          {activeCombatChain.overpower ? (
-            <div className={styles.icon} data-tooltip="Overpower">
-              <GiElectric />
-            </div>
-          ) : null}
-          {activeCombatChain.fused ? (
-            <div className={styles.icon} data-tooltip="Fused">
-              <GiZigzagLeaf />
-            </div>
-          ) : null}
-          {activeCombatChain.damagePrevention ? (
-            <div
-              className={styles.icon}
-              data-tooltip={`${activeCombatChain.damagePrevention} Damage Prevention`}
-            >
-              <GiShield />
-              {activeCombatChain.damagePrevention}
-            </div>
-          ) : null}
-        </div>
+        <CardDisplay card={attCard} activeCombatChain={activeCombatChain}/>
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes: https://github.com/Talishar/Talishar-FE/issues/270

We had two overlays one in CurrentAttack and one in CardDisplay. The one in CurrentAttack was sitting on top of CardDisplay so if we had an active chain link icons we hid the CardDisplay icons.

I moved the icons inside of Current Attack into Card Display as  ActiveChainCounters and moved the other icons to ContinousCounters. Then made the two siblings so they share one overlay and flexbox. Added a wrap to the flexbox so we can support up to 6ish counters without an issue.

Fixed a bug with tooltips getting the text shadow of the parent div and cleaned up the tool tips for ContinousCounters so we don't need to display `(s)` or 1.

![image](https://user-images.githubusercontent.com/8871975/229561265-51a1f07e-cccb-4cd0-83ca-588944e01dd9.png)

 