### PR TITLE
Rework action point display

### DIFF
--- a/src/routes/game/components/elements/actionPointDisplay/ActionPointDisplay.module.css
+++ b/src/routes/game/components/elements/actionPointDisplay/ActionPointDisplay.module.css
@@ -5,19 +5,26 @@
 }
 
 .actionPointCounter {
-  border-radius: 100%;
+  border-radius: 4px;
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 2em;
-  width: 2em;
-  background-image: url('../../../../../img/elements/turnwidget/turnWidget-ActionPoint.png');
-  background-position: center;
-  background-size: contain;
+  height: 3em;
+  width: 3em;
+  background: rgba(80, 80, 80, 0.5);
+  border: 1px solid gray;
   text-align: center;
   font-size: 1.5em;
   color: var(--white);
   text-shadow: -1px 1px 2px #000, 1px 1px 2px #000, 1px -1px 0 #000,
     -1px -1px 0 #000;
   z-index: -1;
+}
+
+.IHavePriority {
+  backrgound-color: limegreen;
+}
+
+.TheyHavePriority {
+  backrgound-color: red;
 }

--- a/src/routes/game/components/elements/actionPointDisplay/ActionPointDisplay.tsx
+++ b/src/routes/game/components/elements/actionPointDisplay/ActionPointDisplay.tsx
@@ -12,9 +12,12 @@ export default function ActionPointDisplay(props: Player) {
     )
   );
 
+  const ActivePlayer = useAppSelector((state: RootState) =>
+    state.game.activePlayer
+  );
   return (
     <div className={styles.actionPointDisplay}>
-      <div className={styles.actionPointCounter}>{APAvailable}</div>
+      <div className={`${styles.actionPointCounter}`}>{APAvailable} AP</div>
     </div>
   );
 }


### PR DESCRIPTION
Reworked action point display to be clearer what it's for (AP indicator) and also to be more consistent with the style of other UI elements (kind of a smoky gray color scheme)

After:
![image](https://user-images.githubusercontent.com/77394768/229951737-14ff92a7-5db5-4c55-abd7-957c7e3ebd1b.png)

Closes #251 
