### PR TITLE
create separate component for opt popups, fix styling in new popup

### DIFF
--- a/src/routes/game/components/elements/playerInputPopUp/PlayerInputPopUp.module.css
+++ b/src/routes/game/components/elements/playerInputPopUp/PlayerInputPopUp.module.css
@@ -99,6 +99,30 @@
   gap: 1vh;
 }
 
+.optForm.optForm{
+  flex-direction: row;
+  margin-bottom: 0;
+}
+
+.optForm .buttonRow{
+  display: flex;
+  margin-top: .5rem;
+  align-items: center;
+}
+
+.optForm .buttonDiv {
+  margin: 0 .25em;
+}
+
+.optForm .cardDiv{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-height: none;
+  max-width:none;
+  height: 100%;
+}
+
 .cardList {
   display: flex;
   flex-direction: row;

--- a/src/routes/game/components/elements/playerInputPopUp/PlayerInputPopUp.tsx
+++ b/src/routes/game/components/elements/playerInputPopUp/PlayerInputPopUp.tsx
@@ -113,6 +113,8 @@ export default function PlayerInputPopUp() {
   }) || [];
 
   const FormDisplay = PlayerInputFormTypeMap[inputPopUp.popup?.id || ''] || OtherInput;
+  //Title comes back as a HTML string so we need to dangeously set it vs just using it for the moment
+  const title = { __html: inputPopUp?.popup?.title ?? '' };
   return (
     <motion.div
       initial={{ opacity: 0, scale: 0.8 }}
@@ -123,7 +125,7 @@ export default function PlayerInputPopUp() {
     >
       <div className={styles.optionsTitleContainer}>
         <div className={styles.optionsTitle}>
-          <h3 className={styles.title}> {inputPopUp.popup?.title ?? ''}</h3>
+          <h3 className={styles.title} dangerouslySetInnerHTML={title}></h3>
           {inputPopUp.popup?.additionalComments}
         </div>
         {inputPopUp.popup?.canClose ? (

--- a/src/routes/game/components/elements/playerInputPopUp/PlayerInputPopUp.tsx
+++ b/src/routes/game/components/elements/playerInputPopUp/PlayerInputPopUp.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import { submitButton, submitMultiButton } from 'features/game/GameSlice';
 import { useAppSelector, useAppDispatch } from 'app/Hooks';
 import { RootState } from 'app/Store';
@@ -11,9 +11,19 @@ import { PROCESS_INPUT } from 'appConstants';
 import { NAME_A_CARD } from './constants';
 import { motion, AnimatePresence } from 'framer-motion';
 import useShowModal from 'hooks/useShowModals';
+import { OptInput } from './components/OptInput';
+import { FormProps } from './playerInputPopupTypes';
+import { OtherInput } from './components/OtherInput';
+
+const PlayerInputFormTypeMap: {
+  [key: string]: (props: FormProps) => JSX.Element;
+} = {
+  OPT: OptInput
+};
 
 export default function PlayerInputPopUp() {
   const showModal = useShowModal();
+  const dispatch = useAppDispatch();
   const inputPopUp = useAppSelector(
     (state: RootState) => state.game.playerInputPopUp
   );
@@ -23,25 +33,17 @@ export default function PlayerInputPopUp() {
   );
 
   useEffect(() => {
-    const cardsArrLength =
-      inputPopUp?.popup?.cards?.length !== undefined
-        ? inputPopUp?.popup?.cards?.length
-        : 0;
-    const optionsArrLength =
-      inputPopUp?.multiChooseText?.length !== undefined
-        ? inputPopUp?.multiChooseText?.length
-        : 0;
+    const cardsArrLength = inputPopUp?.popup?.cards?.length ?? 0;
+    const optionsArrLength = inputPopUp?.multiChooseText?.length ?? 0;
     const checkBoxLength = Math.max(cardsArrLength, optionsArrLength);
     setCheckedState(new Array(checkBoxLength).fill(false));
   }, [inputPopUp]);
-
-  const dispatch = useAppDispatch();
 
   const onPassTurn = () => {
     dispatch(submitButton({ button: { mode: PROCESS_INPUT.PASS } }));
   };
 
-  const clickButton = (button: Button) => {
+  const onClickButton = (button: Button) => {
     dispatch(submitButton({ button: button }));
   };
 
@@ -53,8 +55,6 @@ export default function PlayerInputPopUp() {
   ) {
     return null;
   }
-
-  const title = { __html: inputPopUp.popup?.title ?? '' };
 
   const checkBoxSubmit = () => {
     let extraParams = `&chkCount=${checkedState.length}`;
@@ -84,44 +84,6 @@ export default function PlayerInputPopUp() {
     );
   };
 
-  const buttons = inputPopUp.buttons?.map((button, ix) => {
-    return (
-      <div
-        className={styles.buttonDiv}
-        onClick={() => {
-          clickButton(button);
-        }}
-        key={ix.toString()}
-      >
-        {button.caption}
-      </div>
-    );
-  });
-
-  // cards
-  const selectCard = inputPopUp.popup?.cards?.map((card, ix) => {
-    return inputPopUp.choiceOptions == 'checkbox' ? (
-      <div
-        key={ix.toString()}
-        className={styles.cardDiv}
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          handleCheckBoxChange(Number(card.actionDataOverride));
-        }}
-      >
-        <CardDisplay
-          card={{ borderColor: checkedState[ix] ? '8' : '', ...card }}
-          preventUseOnClick
-        />
-      </div>
-    ) : (
-      <div className={styles.cardDiv} key={ix.toString()}>
-        <CardDisplay card={card} />
-      </div>
-    );
-  });
-
   const handleCheckBoxChange = (pos: number | undefined) => {
     if (pos === undefined) {
       return;
@@ -148,8 +110,9 @@ export default function PlayerInputPopUp() {
         </label>
       </div>
     );
-  });
+  }) || [];
 
+  const FormDisplay = PlayerInputFormTypeMap[inputPopUp.popup?.id || ''] || OtherInput;
   return (
     <motion.div
       initial={{ opacity: 0, scale: 0.8 }}
@@ -160,7 +123,7 @@ export default function PlayerInputPopUp() {
     >
       <div className={styles.optionsTitleContainer}>
         <div className={styles.optionsTitle}>
-          <h3 className={styles.title} dangerouslySetInnerHTML={title}></h3>
+          <h3 className={styles.title}> {inputPopUp.popup?.title ?? ''}</h3>
           {inputPopUp.popup?.additionalComments}
         </div>
         {inputPopUp.popup?.canClose ? (
@@ -170,30 +133,18 @@ export default function PlayerInputPopUp() {
         ) : null}
       </div>
       <div className={styles.contentContainer}>
-        <form className={styles.form}>
-          {selectCard?.length != 0 ? (
-            <div className={styles.cardList}>{selectCard}</div>
-          ) : null}
-          {buttons?.length != 0 ? (
-            <div className={styles.buttonList}>{buttons}</div>
-          ) : null}
-          <div>
-            {inputPopUp.formOptions ? (
-              <div>
-                {checkboxes?.length != 0 ? <div>{checkboxes}</div> : null}
-                <div
-                  className={styles.buttonDiv}
-                  onClick={() => {
-                    checkBoxSubmit();
-                  }}
-                >
-                  {inputPopUp.formOptions.caption}
-                </div>
-              </div>
-            ) : null}
-            {inputPopUp?.popup?.id === NAME_A_CARD && <SearchCardInput />}
-          </div>
-        </form>
+        <FormDisplay
+          cards={inputPopUp.popup?.cards || []}
+          buttons={inputPopUp.buttons || []}
+          onClickButton={onClickButton}
+          id={inputPopUp.popup?.id || ''}
+          choiceOptions={inputPopUp.choiceOptions || ''}
+          checkedState={checkedState}
+          handleCheckBoxChange={handleCheckBoxChange}
+          formOptions={inputPopUp.formOptions}
+          checkboxes={checkboxes}
+          checkBoxSubmit={checkBoxSubmit}
+        />
       </div>
     </motion.div>
   );

--- a/src/routes/game/components/elements/playerInputPopUp/components/OptInput.tsx
+++ b/src/routes/game/components/elements/playerInputPopUp/components/OptInput.tsx
@@ -1,0 +1,59 @@
+import Button from 'features/Button';
+import { Card } from 'features/Card';
+import CardDisplay from '../../cardDisplay/CardDisplay';
+import { FormProps } from '../playerInputPopupTypes';
+import styles from '../PlayerInputPopUp.module.css';
+import classNames from 'classnames';
+
+interface CardWithButtons extends Card {
+  buttons: Button[];
+  key: number;
+}
+
+type OptOptionBoxProps = {
+  card: CardWithButtons;
+  onClickButton: (b: Button) => void;
+};
+
+const OptOptionBox = ({ card, onClickButton }: OptOptionBoxProps) => {
+  return (
+    <div className={styles.cardDiv} key={card.key.toString()}>
+      <CardDisplay card={card} />
+      <div className={styles.buttonRow}>
+        {card?.buttons.map((button: Button, bid) => (
+          <div
+            className={styles.buttonDiv}
+            onClick={() => {
+              onClickButton(button);
+            }}
+            key={bid.toString()}
+          >
+            {button.caption}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const OptInput = (props: FormProps) => {
+  const { cards, buttons, onClickButton, id } = props;
+
+  const cardWithButtons = cards.map((card, index) => {
+    return {
+      ...card,
+      key: index,
+      buttons: buttons.filter(
+        (button) => button.buttonInput === card.cardNumber
+      )
+    };
+  });
+
+  return (
+    <form className={classNames(styles.form, styles.optForm)}>
+      {cardWithButtons.map((card, id) => (
+        <OptOptionBox card={card} onClickButton={onClickButton} key={id} />
+      ))}
+    </form>
+  );
+};

--- a/src/routes/game/components/elements/playerInputPopUp/components/OtherInput.tsx
+++ b/src/routes/game/components/elements/playerInputPopUp/components/OtherInput.tsx
@@ -1,0 +1,85 @@
+import CardDisplay from '../../cardDisplay/CardDisplay';
+import SearchCardInput from '../../searchCardInput/SearchCardInput';
+import { NAME_A_CARD } from '../constants';
+import { FormProps } from '../playerInputPopupTypes';
+import styles from '../PlayerInputPopUp.module.css';
+
+
+export const OtherInput = (props: FormProps) => {
+  const {
+    cards,
+    buttons,
+    choiceOptions,
+    checkedState,
+    handleCheckBoxChange,
+    onClickButton,
+    id,
+    formOptions,
+    checkboxes,
+    checkBoxSubmit
+  } = props;
+
+  const selectCard = cards?.map((card, ix) => {
+    return choiceOptions == 'checkbox' ? (
+      <div
+        key={ix.toString()}
+        className={styles.cardDiv}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          handleCheckBoxChange(Number(card.actionDataOverride));
+        }}
+      >
+        <CardDisplay
+          card={{ borderColor: checkedState[ix] ? '8' : '', ...card }}
+          preventUseOnClick
+        />
+      </div>
+    ) : (
+      <div className={styles.cardDiv} key={ix.toString()}>
+        <CardDisplay card={card} />
+      </div>
+    );
+  });
+
+  return (
+    <form className={styles.form}>
+      {selectCard?.length != 0 ? (
+        <div className={styles.cardList}>{selectCard}</div>
+      ) : null}
+      {buttons?.length != 0 
+        ? <div className={styles.buttonList}>
+            { buttons?.map((button, ix) => {
+                return (
+                  <div
+                    className={styles.buttonDiv}
+                    onClick={() => {
+                      onClickButton(button);
+                    }}
+                    key={ix.toString()}
+                  >
+                    {button.caption}
+                  </div>
+                );
+            })}
+          </div>
+      : null }
+      <div>
+        {formOptions ? (
+          <div>
+            {checkboxes?.length != 0 ? <div>{checkboxes}</div> : null}
+            <div
+              className={styles.buttonDiv}
+              onClick={() => {
+                checkBoxSubmit();
+              }}
+            >
+              {formOptions.caption}
+            </div>
+          </div>
+        ) : null}
+        {id === NAME_A_CARD && <SearchCardInput />}
+      </div>
+    </form>
+  )
+}

--- a/src/routes/game/components/elements/playerInputPopUp/playerInputPopupTypes.d.ts
+++ b/src/routes/game/components/elements/playerInputPopUp/playerInputPopupTypes.d.ts
@@ -1,0 +1,15 @@
+import React from "react";
+
+export interface FormProps{
+  cards: Card[],
+  buttons: Button[],
+  onClickButton: (button: Button) => void,
+  id: 'OPT' | string,
+  choiceOptions: string,
+  checkedState: boolean[],
+  handleCheckBoxChange: (cardActivationNumber: number) => void,
+  id: string,
+  formOptions: GameState.playerInputPopUp,
+  checkboxes: React.ReactElement[],
+  checkBoxSubmit: () => void
+};


### PR DESCRIPTION
So the issue is due to us using the same form for when we need a submit button, when we have text options and when we have opt options. 

To make this fix more long term. I have broken out popups of id OPT into a new form component and created and other form component to have a fallback. Moving forward this will allow us to do different things in the popup using the ID to define the layout style for the form.

![image](https://user-images.githubusercontent.com/8871975/229982127-28a3e3eb-9089-4c31-aaa4-e55ec568f354.png)

![image](https://user-images.githubusercontent.com/8871975/229982240-2bd55545-9c68-4a45-8d44-f3ed04a6c84e.png)

Test Deck Link: https://fabrary.net/decks/01GX2F3RM59TYDSWFK1T92MFCY