### PR TITLE
Add a hide popup Button on endscreen

### DIFF
--- a/src/routes/game/components/elements/endGameScreen/EndGameScreen.module.css
+++ b/src/routes/game/components/elements/endGameScreen/EndGameScreen.module.css
@@ -13,6 +13,10 @@
   z-index: 10;
 }
 
+.cardListBox.reduced {
+  bottom: auto;
+}
+
 .cardListTitleContainer {
   position: relative;
   display: flex;
@@ -50,6 +54,11 @@
 .cardListCloseIcon:hover {
   background-color: var(--primary);
   color: black;
+}
+
+.buttonGroup {
+  display: flex;
+  gap: 0.5em;
 }
 
 .buttonDiv {

--- a/src/routes/game/components/elements/endGameScreen/EndGameScreen.tsx
+++ b/src/routes/game/components/elements/endGameScreen/EndGameScreen.tsx
@@ -8,6 +8,7 @@ import EndGameStats, { EndGameData } from '../endGameStats/EndGameStats';
 import { shallowEqual } from 'react-redux';
 import useShowModal from 'hooks/useShowModals';
 import { FaEye, FaEyeSlash } from "react-icons/fa";
+import classNames from "classnames";
 
 const EndGameScreen = () => {
   const gameInfo = useAppSelector(getGameInfo, shallowEqual);
@@ -20,6 +21,9 @@ const EndGameScreen = () => {
     popupType: END_GAME_STATS
   });
   const showModal = useShowModal();
+  const cardListBoxClasses = classNames(styles.cardListBox, {
+    [styles.reduced]: !showStats
+  })
 
   if (!showModal) return null;
 
@@ -42,7 +46,7 @@ const EndGameScreen = () => {
   }
 
   return (
-    <div className={`${styles.cardListBox} ${!showStats ? styles.reduced : ''}`}>
+    <div className={cardListBoxClasses}>
       <div className={styles.cardListTitleContainer}>
         <div className={styles.cardListTitle}>
           <h3 className={styles.title}>{'Game Over Summary'}</h3>

--- a/src/routes/game/components/elements/endGameScreen/EndGameScreen.tsx
+++ b/src/routes/game/components/elements/endGameScreen/EndGameScreen.tsx
@@ -7,10 +7,12 @@ import { getGameInfo } from 'features/game/GameSlice';
 import EndGameStats, { EndGameData } from '../endGameStats/EndGameStats';
 import { shallowEqual } from 'react-redux';
 import useShowModal from 'hooks/useShowModals';
+import { FaEye, FaEyeSlash } from "react-icons/fa";
 
 const EndGameScreen = () => {
   const gameInfo = useAppSelector(getGameInfo, shallowEqual);
   const [playerID, setPlayerID] = useState(gameInfo.playerID === 2 ? 2 : 1);
+  const [showStats, setShowStats] = useState(true);
   const { data, isLoading, error } = useGetPopUpContentQuery({
     gameID: gameInfo.gameID,
     playerID: playerID,
@@ -35,17 +37,26 @@ const EndGameScreen = () => {
     playerID === 2 ? setPlayerID(1) : setPlayerID(2);
   };
 
+  const toggleShowStats = () => {
+    setShowStats(!showStats);
+  }
+
   return (
-    <div className={styles.cardListBox}>
+    <div className={`${styles.cardListBox} ${!showStats ? styles.reduced : ''}`}>
       <div className={styles.cardListTitleContainer}>
         <div className={styles.cardListTitle}>
           <h3 className={styles.title}>{'Game Over Summary'}</h3>
-          <div className={styles.buttonDiv} onClick={switchPlayer}>
-            Switch player stats
+          <div className={styles.buttonGroup}>
+            <div className={styles.buttonDiv} onClick={switchPlayer}>
+              Switch player stats
+            </div>
+            <div className={styles.buttonDiv} onClick={toggleShowStats}>
+              {showStats ? <FaEye aria-hidden="true" fontSize={'2em'} /> : <FaEyeSlash aria-hidden="true" fontSize={'2em'} />}
+            </div>
           </div>
         </div>
       </div>
-      {content}
+      {showStats && content}
     </div>
   );
 };


### PR DESCRIPTION
Implementing a toggle button to the endscreen.
On click it will hide the content of the endscreen and make the rest of the arena (like graveyard, banished zones,etc.) accessible.

Closes #344

Endscreen expanded:
![Screenshot 2023-04-30 025739](https://user-images.githubusercontent.com/12810590/235331597-21400a1d-79d7-408f-9731-04264045e570.png)

Endscreen hidden:
![Screenshot 2023-04-30 025710](https://user-images.githubusercontent.com/12810590/235331600-348483be-b6b8-4905-9c89-cdbf711c2068.png)
