### PR TITLE
Changes to card preview css for mobile portrait mode.

### DIFF
--- a/src/routes/game/components/elements/cardPortal/CardPortal.module.css
+++ b/src/routes/game/components/elements/cardPortal/CardPortal.module.css
@@ -36,7 +36,7 @@
 
 
 
-@media (max-width: 1000px) {
+@media (orientation: portrait) {
     .popUpContainer {
       bottom: auto !important;
       right: auto !important;

--- a/src/routes/game/components/elements/cardPortal/CardPortal.module.css
+++ b/src/routes/game/components/elements/cardPortal/CardPortal.module.css
@@ -33,3 +33,23 @@
   position: absolute;
   left: -40vh;
 }
+
+
+
+@media (max-width: 1000px) {
+    .popUpContainer {
+      bottom: auto !important;
+      right: auto !important;
+      left: auto !important;
+      top: auto !important;
+      height: 100dvh !important;
+    }
+
+    .img {
+      height: 40vh;
+    }
+
+    .doubleFacedCard {
+      position: static;
+    }
+}


### PR DESCRIPTION
The scaling and placement of the card preview on mobile portrait mode were off. Now you can see normal as well as double-faced cards entirely and in the correct width/height ratio.

Before:
![image](https://github.com/Talishar/Talishar-FE/assets/145457663/aee9bf6a-bf59-4eb4-b232-754b929c8080)
![image](https://github.com/Talishar/Talishar-FE/assets/145457663/79d41f33-3323-4248-9169-d0fd7bea4b98)



After:
![image](https://github.com/Talishar/Talishar-FE/assets/145457663/6cfb1229-0991-4cae-8d3d-0ab11081a992)
![image](https://github.com/Talishar/Talishar-FE/assets/145457663/082b834b-462e-4759-856b-2dc720cd7fdc)
