### PR TITLE
Tweaked mobile css, now able to click trough card preview to interact with board

### DIFF
--- a/src/routes/game/components/elements/cardPortal/CardPortal.module.css
+++ b/src/routes/game/components/elements/cardPortal/CardPortal.module.css
@@ -35,21 +35,23 @@
 }
 
 
-
 @media (orientation: portrait) {
-    .popUpContainer {
-      /* bottom: auto !important; */
-      right: auto !important;
-      left: auto !important;
-      top: auto !important;
-      height: 60dvh !important;
-    }
+  .popUpContainer {
+    bottom: auto !important;
+    right: auto !important;
+    left: auto !important;
+    top: auto !important;
+    height: 90dvh !important;
 
-    .img {
-      height: 40vh;
-    }
+    pointer-events: none;
+    background: url('../../../../../img/backgrounds/transparent-card.png');
+  }
 
-    .doubleFacedCard {
-      position: static;
-    }
+  .img {
+    height: 40dvh;
+  }
+
+  .doubleFacedCard {
+    position: static;
+  }
 }


### PR DESCRIPTION
Sorry for the mess I left behind yesterday. I basically reimplemented the CSS I made yesterday, but now you're able to click through the preview. Now stuff can be played from arsenal/board again. 

However since  #437 there appears an issue on my mobile where I will hover over a card and the image context menu will pop up. "user select: none;" usually gets rid of this but I'm now sure where to apply right now and will look into it later.