### PR TITLE
[fix]: issue #535 restricted number of cards shown in pitch zone

### DIFF
--- a/src/routes/game/components/zones/pitchZone/PitchZone.test.tsx
+++ b/src/routes/game/components/zones/pitchZone/PitchZone.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { store } from 'app/Store';
+import { globalInitialState, store } from 'app/Store';
 import { createRoot } from 'react-dom/client';
+import { renderWithProviders } from 'utils/TestUtils';
+import { OfflineTestingGameState } from 'features/game/InitialGameState';
+import { screen } from '@testing-library/react';
+
 import PitchZone from './PitchZone';
 
 it('renders without crashing isPlayer true', () => {
@@ -22,4 +26,25 @@ it('renders without crashing isPlayer false', () => {
       <PitchZone isPlayer={false} DisplayRow="" />
     </Provider>
   );
+});
+
+describe('When rendering the pitch zone', () => {
+  it('When a user pitches, it should not show more than 4 cards', async () => {
+      const initialState = {
+        ...globalInitialState,
+        game: {
+          ...OfflineTestingGameState,
+          playerOne: {
+            ...OfflineTestingGameState.playerOne,
+            Pitch: new Array(5).fill({ cardNumber: 'ARC003' }, 0, 5)
+          }
+        }
+      };
+
+      renderWithProviders(<PitchZone isPlayer DisplayRow="" />, {
+        preloadedState: initialState
+      });
+
+      expect(screen.getAllByTestId('pitch-motion-div')).toHaveLength(4);
+  });
 });

--- a/src/routes/game/components/zones/pitchZone/PitchZone.tsx
+++ b/src/routes/game/components/zones/pitchZone/PitchZone.tsx
@@ -54,7 +54,7 @@ export default function PitchZone(prop: Displayrow) {
   return (
     <div className={styles.pitchZone} onClick={pitchZoneDisplay}>
       <AnimatePresence>
-        {pitchOrder.map((card, ix) => {
+        {pitchOrder.slice(0, 4).map((card, ix) => {
           return (
             <motion.div
               style={{ top: `-${1.5 * ix}em`, zIndex: `-${ix + 1}` }}
@@ -64,6 +64,7 @@ export default function PitchZone(prop: Displayrow) {
               transition={{ ease: 'easeIn', duration: 0.2 }}
               exit={{ opacity: 0 }}
               key={`${card.cardNumber}-${ix}`}
+              data-testid='pitch-motion-div'
             >
               <CardDisplay card={card} preventUseOnClick />
             </motion.div>


### PR DESCRIPTION
Fixes #535 

Added a maximum of 4 cards being displayed at a time in the pitch zone. Extra pitches are still shown if the user clicks in the pitch stack.