### PR TITLE
Disable contextMenu for PlayerHand and Equipment

### DIFF
--- a/src/routes/game/components/elements/playerHandCard/PlayerHandCard.tsx
+++ b/src/routes/game/components/elements/playerHandCard/PlayerHandCard.tsx
@@ -87,8 +87,10 @@ export const PlayerHandCard = ({
   const onDrag = () => {
     if (canPopUp) {
       setSnapback(true);
-      dispatch(clearPopUp());
-      setCanPopup(false);
+      if (!isLongPress.current) {
+        dispatch(clearPopUp());
+        setCanPopup(false);
+      }
     }
   };
 

--- a/src/routes/game/components/zones/playerHand/PlayerHand.tsx
+++ b/src/routes/game/components/zones/playerHand/PlayerHand.tsx
@@ -105,7 +105,7 @@ export default function PlayerHand() {
     <>
       {createPortal(
         <>
-          <div className={styles.handRow}>
+          <div className={styles.handRow} onContextMenu={(e)=> e.preventDefault()}>
             <AnimatePresence>
               {handCards !== undefined &&
                 handCards.map((card, ix) => {

--- a/src/routes/game/lobby/components/equipment/Equipment.module.css
+++ b/src/routes/game/lobby/components/equipment/Equipment.module.css
@@ -21,6 +21,7 @@
 .cardContainer {
   height: 100px;
   width: 100px;
+  -webkit-touch-callout: none;
 }
 
 .card {

--- a/src/routes/game/lobby/components/equipment/Equipment.tsx
+++ b/src/routes/game/lobby/components/equipment/Equipment.tsx
@@ -33,7 +33,7 @@ const Equipment = ({ lobbyInfo, weapons, weaponSB }: EquipmentProps) => {
     getCollectionCardImagePath({ path: CARD_SQUARES_PATH, locale, cardNumber });
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} onContextMenu={(e)=> e.preventDefault()}>
       <div className={styles.eqCategory}>
         <h3>Weapons / Off-Hand</h3>
         <FieldArray


### PR DESCRIPTION
This is for #464 so that holding to view card pop up does not trigger the menu on mobile.

This also prevents right clicks from creating the context menu on those elements, but seems like the easiest way to fix #464 if you don't mind that players will not be able to right click on some UI elements.

I tried other ways of fixing it like adding a div overlay in CardImage which works on PlayerHand but the context menu still pops up in the Lobby when hovering over equipment. Other elements do not seem to have this issue though.

This is still not very nice as slighting moving your finger will cause the card view to disappear, so I made some changes so that after long clicking/pressing the card, dragging will not clear the pop up.