### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/src/routes/game/components/zones/activeLayersZone/ActiveLayersZone.tsx
+++ b/src/routes/game/components/zones/activeLayersZone/ActiveLayersZone.tsx
@@ -112,7 +112,7 @@ const Target = ({ target }: { target: string | undefined }) => {
       <span
         className={styles.target}
         dangerouslySetInnerHTML={{
-          __html: replaceText(target?.replace('|', ', '))
+          __html: replaceText(target?.replace(/\|/g, ', '))
         }}
       ></span>
     </div>


### PR DESCRIPTION
Potential fix for [https://github.com/Talishar/Talishar-FE/security/code-scanning/3](https://github.com/Talishar/Talishar-FE/security/code-scanning/3)

In general, to correctly replace all occurrences of a substring in JavaScript/TypeScript, you should use a regular expression with the `g` ("global") flag instead of a string as the first argument to `replace`. Here, update `target?.replace('|', ', ')` to `target?.replace(/\|/g, ', ')` in the call on line 115. This change only affects the local `replace` operation and does not interfere with other logic or the actual escaping/sanitization performed in `replaceText`.

Only the replacement of that one line is required and no new imports or additional functions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
