### PR TITLE
Add middle-click as pass shortcut

### DIFF
--- a/src/appConstants.ts
+++ b/src/appConstants.ts
@@ -123,6 +123,7 @@ export const PROCESS_INPUT = {
 export const DEFAULT_SHORTCUTS = {
   TOGGLE_OPTIONS_MENU: 'KeyM',
   PASS_TURN: 'Space',
+  PASS_MIDDLE_CLICK: 'MiddleClick',
   CLOSE_WINDOW: 'Escape',
   UNDO: 'KeyU',
   UNDOALT: 'KeyZ',

--- a/src/routes/game/components/elements/experimentalTurnWidget/ExperimentalTurnWidget.tsx
+++ b/src/routes/game/components/elements/experimentalTurnWidget/ExperimentalTurnWidget.tsx
@@ -231,6 +231,7 @@ export function PassTurnDisplay() {
   };
 
   useShortcut(DEFAULT_SHORTCUTS.PASS_TURN, onPassTurn);
+  useShortcut(DEFAULT_SHORTCUTS.PASS_MIDDLE_CLICK, onPassTurn);
 
   const clickYes = (e: any) => {
     e.preventDefault();

--- a/src/routes/game/components/elements/passTurnDisplay/PassTurnDisplay.tsx
+++ b/src/routes/game/components/elements/passTurnDisplay/PassTurnDisplay.tsx
@@ -36,9 +36,9 @@ export default function PassTurnDisplay() {
   );
   const settingsData = useAppSelector(getSettingsEntity);
   const initialValues = { mute: settingsData['MuteSound']?.value === '1' };
-  
+
   const dispatch = useAppDispatch();
-  
+
   useEffect(() => {
     if (hasPriority && !initialValues.mute && playerID !== 3) {
       playPassTurnSound();
@@ -90,6 +90,7 @@ export default function PassTurnDisplay() {
   }, [showAreYouSureModal, dispatch]);
 
   useShortcut(DEFAULT_SHORTCUTS.PASS_TURN, onPassTurn);
+  useShortcut(DEFAULT_SHORTCUTS.PASS_MIDDLE_CLICK, onPassTurn);
   useShortcut(DEFAULT_SHORTCUTS.UNDO, onUndoKeyPress);
 
   const clickYes = (e: React.SyntheticEvent<HTMLButtonElement>) => {
@@ -114,7 +115,7 @@ export default function PassTurnDisplay() {
     // Fallback to checking hasPriority if priorityPlayer is undefined
     const priority = priorityPlayer ?? (hasPriority ? 1 : 2);
     const arrow = priority === 1 ? '▲' : '▼';
-    
+
     return (
       <div className={styles.passTurnDisplay}>
         <div className={styles.spectatorDisplay}>


### PR DESCRIPTION
Adds middle-click as a shortcut to pass priority, alongside the existing spacebar and Pass button.

## Changes
- Extended `useShortcut` hook to support mouse button codes (e.g. `MiddleClick`) in addition to keyboard codes
- Added `PASS_MIDDLE_CLICK` to `DEFAULT_SHORTCUTS`
- Registered the new shortcut in both `PassTurnDisplay` components

Closes #580