### PR TITLE
show friends-only open games to friends in lobby

### DIFF
--- a/src/routes/index/components/gameList/GameList.tsx
+++ b/src/routes/index/components/gameList/GameList.tsx
@@ -385,8 +385,8 @@ const GameList = () => {
             return false;
           }
 
-          // Hide friends-only private games (visibility "2") - these can't be spectated
-          if (game.visibility === '2') {
+          // Hide friends-only games from non-friends
+          if (game.visibility === '2' && !(game.gameCreator && friendUsernames.has(game.gameCreator))) {
             return false;
           }
 


### PR DESCRIPTION
This is a proposal PR.

Currently, when a friend creates a friends-only game, it does not appear in the lobby, so players have to share the URL manually to join. Showing the room in the lobby would eliminate the need for URL sharing and make
the experience smoother.

One downside is that a not-so-close friend might join a room that was intended to be more private. However, since both parties are already friends, I think this drawback is minor.

The screenshots from left to right show: the creator of the friends-only game, a non-friend player, a player joining the friends-only game, and another friend.

<img width="3837" height="2006" alt="スクリーンショット 2026-04-29 12 42 34" src="https://github.com/user-attachments/assets/62fcf2b4-b6ac-4bf6-a32a-b0ebcc1b1989" />
<img width="3840" height="2009" alt="スクリーンショット 2026-04-29 12 49 56" src="https://github.com/user-attachments/assets/50a2ad40-4a4c-4e30-99e3-28ac359d735f" />
