### PR TITLE
Show matchups panel for FaB Bazaar decks

### DIFF
--- a/src/routes/game/lobby/Lobby.tsx
+++ b/src/routes/game/lobby/Lobby.tsx
@@ -127,8 +127,7 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
   const isBazaarDeckInLobby = !!extractBazaarDeckIdFromLink(
     gameLobby?.myDeckLink
   );
-  const shouldShowMatchupsUI =
-    !isBazaarDeckInLobby && (gameLobby?.matchups?.length ?? 0) > 0;
+  const shouldShowMatchupsUI = (gameLobby?.matchups?.length ?? 0) > 0;
   const [playLobbyJoin] = useSound(playerJoined, { volume: 1 });
   const settingsData = useAppSelector(getSettingsEntity);
   const isMuted = settingsData['MuteSound']?.value === '1';
@@ -282,11 +281,6 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
     setHasMatchups(shouldShowMatchupsUI);
   }, [shouldShowMatchupsUI]);
 
-  useEffect(() => {
-    if (isBazaarDeckInLobby && activeTab === 'matchups') {
-      setActiveTab('equipment');
-    }
-  }, [isBazaarDeckInLobby, activeTab]);
 
   useEffect(() => {
     // New lobby/deck context: clear stale selected matchup from previous session.


### PR DESCRIPTION
## Summary

When a FaB Bazaar deck is loaded in the lobby, the matchups panel was hidden entirely and users were redirected off the matchups tab. This meant the auto-applied matchup (which fires when the opponent's hero is detected) was invisible and couldn't be overridden manually.

This PR removes that exclusion so Bazaar decks behave the same as any other deck source — show the panel when matchups exist, let the user pick a different one if they want.

## Changes

- Removed `!isBazaarDeckInLobby &&` guard from `shouldShowMatchupsUI` so the matchups tab and panel render for Bazaar decks
- Removed the `useEffect` that redirected users off the matchups tab when a Bazaar deck was loaded

## Behaviour

- Auto-apply still fires as before — correct matchup is selected automatically when opponent hero is detected
- User can now see which matchup was applied and switch to a different one if they want
- No change for non-Bazaar users

## FaB Bazaar API

The FaB Bazaar `/api/talishar/decks` endpoint now returns both `id` and `deckId` on each deck object. `deckId` is what the `BazaarDeck` interface expects, while `id` is kept for backwards compatibility with anything else consuming that endpoint.