### PR TITLE
Lobby redesign + matchups panel with legalHeroes consumer

### DIFF
--- a/src/interface/API/GetLobbyRefresh.php.ts
+++ b/src/interface/API/GetLobbyRefresh.php.ts
@@ -28,6 +28,7 @@ export interface GetLobbyRefreshResponse {
   canUnreadySideboard?: boolean;
   myDeckLink?: string;
   matchups?: Matchup[];
+  legalHeroes?: LegalHero[];
   chatEnabled?: boolean;
   chatInvited?: boolean;
   opponentIsTyping?: boolean;
@@ -39,4 +40,18 @@ export interface Matchup {
   name: string;
   preferredTurnOrder?: string | null; // "1st", "2nd", or null
   notes?: string | null; // HTML notes from Fabrary
+}
+
+// Heroes the backend has determined are legal for the current deck's format.
+// Already filtered: bans applied (via JoinGame.php isBannedInFormat),
+// young/adult split applied for the format. The FE renders these directly
+// as the discovery grid for Bazaar decks; no further filtering needed.
+//
+// If absent (older backend versions), the FE falls back to its local
+// HEROES_OF_RATHE constant + young flag — without ban filtering.
+export interface LegalHero {
+  heroId: string;   // slug, e.g. "briar_warden_of_thorns"
+  name: string;     // display name, e.g. "Briar Warden of Thorns"
+  class: string;    // class name from CardClass(): "RUNEBLADE", "WIZARD", "ASSASSIN", etc.
+  young?: boolean;  // optional; backend has already format-filtered, FE doesn't re-filter
 }

--- a/src/routes/game/lobby/Lobby.module.css
+++ b/src/routes/game/lobby/Lobby.module.css
@@ -218,10 +218,9 @@
   text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.9), 0 0 4px rgba(0, 0, 0, 0.8);
   margin-bottom: 0px;
   font-weight: 600;
-  font-size: 0.7em;
+  font-size: 1.1em;
   transition: all 0.3s ease;
   opacity: 0.9;
-  display: none;
 }
 
 .kickButton {

--- a/src/routes/game/lobby/Lobby.module.css
+++ b/src/routes/game/lobby/Lobby.module.css
@@ -6,10 +6,7 @@
 }
 
 .titleContainer {
-  position: -webkit-sticky; /* Safari */
-  position: sticky;
-  top: -208px;
-  height: 240px;
+  height: 120px;
   width: 100%;
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -72,12 +69,20 @@
 @media (min-width: 1200px) {
   .chatAreaContainerRestrained {
     grid-area: chat;
+    grid-row: 1 / span 2;
     min-height: 0;
+    height: 100%;
+    align-self: stretch;
+    padding: 0.75rem 0.5rem 0;
   }
 
   .chatAreaContainer {
     grid-area: chat;
+    grid-row: 1 / span 2;
     min-height: 0;
+    height: 100%;
+    align-self: stretch;
+    padding: 0.75rem 0.5rem 0;
   }
 }
 
@@ -89,7 +94,7 @@
 
 .leftCol {
   background-size: cover;
-  background-position: center;
+  background-position: center 15%;
   height: 100%;
   border: 1px solid rgba(255, 255, 255, 0.1);
   overflow: visible;
@@ -123,7 +128,7 @@
 .rightCol {
   text-align: right;
   background-size: cover;
-  background-position: center;
+  background-position: center 15%;
   height: 100%;
   border: 1px solid rgba(255, 255, 255, 0.1);
   overflow: visible;
@@ -163,8 +168,8 @@
   left: -2px;
   right: -2px;
   bottom: -2px;
-  padding: 1.2em;
-  padding-bottom: 0.8em;
+  padding: 0.4em;
+  padding-bottom: 0.3em;
   color: var(--white);
   text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.9), 0 0 4px rgba(0, 0, 0, 0.8);
   background: linear-gradient(
@@ -189,13 +194,16 @@
 }
 
 .dimPic > h3 {
-  margin-bottom: 0.3em;
-  font-size: 1.3em;
+  margin-bottom: 0.1em;
+  font-size: 0.8em;
   font-weight: 700;
   text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.9), 0 0 4px rgba(0, 0, 0, 0.8);
   color: white;
   transition: all 0.3s ease;
   letter-spacing: 0.5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .leftCol:hover .dimPic > h3,
@@ -210,9 +218,10 @@
   text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.9), 0 0 4px rgba(0, 0, 0, 0.8);
   margin-bottom: 0px;
   font-weight: 600;
-  font-size: 1.1em;
+  font-size: 0.7em;
   transition: all 0.3s ease;
   opacity: 0.9;
+  display: none;
 }
 
 .kickButton {
@@ -290,7 +299,7 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.5rem;
+  padding: 0.2rem 0.5rem;
 }
 
 .inLineNav ul {
@@ -422,11 +431,184 @@
 @media (min-width: 1200px) {
   .deckSelectorContainer {
     grid-area: weapons;
-    grid-row: 1 / span 2;
     display: flex;
     flex-direction: column;
     overflow-y: hidden;
+    height: 100%;
+    align-self: stretch;
+    min-height: 0;
   }
+}
+
+.compactChat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0 0.1rem 0.25rem;
+  height: 100%;
+  overflow: hidden;
+}
+
+.compactChatHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+  padding: 0.35rem 0.2rem 0.4rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: 0.15rem;
+  flex-shrink: 0;
+}
+
+.compactChatHeader::before {
+  content: '';
+  display: inline-block;
+  width: 4px;
+  height: 12px;
+  background: linear-gradient(180deg, #d9b84a 0%, rgba(217, 184, 74, 0.4) 100%);
+  border-radius: 2px;
+}
+
+.compactChatLog {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  font-size: 0.7rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.82);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.025) 0%,
+    rgba(0, 0, 0, 0.18) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 0.5rem 0.55rem;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
+}
+
+.compactChatLog::-webkit-scrollbar {
+  width: 6px;
+}
+
+.compactChatLog::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.compactChatLog::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 3px;
+}
+
+.compactChatLog > div {
+  padding: 0.18rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.compactChatLog > div:last-child {
+  border-bottom: none;
+}
+
+.compactChatEmpty {
+  display: block;
+  color: rgba(255, 255, 255, 0.32);
+  font-style: italic;
+  font-size: 0.68rem;
+  text-align: center;
+  padding: 1.5rem 0;
+  border-bottom: none !important;
+}
+
+.quickChatStrip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.28rem;
+  padding: 0.15rem 0.05rem;
+  flex-shrink: 0;
+}
+
+.quickChatChip {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.22rem 0.55rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.03);
+  color: rgba(255, 255, 255, 0.65);
+  border-radius: 999px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+  width: auto;
+  margin: 0;
+}
+
+.quickChatChip:hover {
+  background: rgba(217, 184, 74, 0.1);
+  color: #f0d070;
+  border-color: rgba(217, 184, 74, 0.4);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.quickChatChip:active {
+  background: rgba(217, 184, 74, 0.18);
+  color: #fff;
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.chatExpandBtn {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid rgba(209, 170, 60, 0.55);
+  background: rgba(209, 170, 60, 0.12);
+  color: #d9b84a;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  width: 100%;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.chatExpandBtn:hover {
+  background: rgba(209, 170, 60, 0.22);
+  color: #f0d070;
+  border-color: rgba(209, 170, 60, 0.8);
+  transform: none;
+  box-shadow: none;
+}
+
+.chatToggleBtn {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  border: 1px solid rgba(209, 170, 60, 0.55);
+  background: rgba(209, 170, 60, 0.12);
+  color: #d9b84a;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  flex-shrink: 0;
+  margin: 0.25rem 0 0.5rem;
+}
+
+.chatToggleBtn:hover {
+  background: rgba(209, 170, 60, 0.22);
+  color: #f0d070;
+  border-color: rgba(209, 170, 60, 0.8);
+  transform: none;
+  box-shadow: none;
 }
 
 nav {
@@ -464,10 +646,12 @@ nav {
   background: transparent;
   border-radius: 0;
   border: none;
-  padding: 1rem;
+  padding: 0.4rem 0.5rem;
   box-shadow:
     0 20px 44px rgba(0, 0, 0, 0.32),
     0 2px 10px rgba(0, 0, 0, 0.22);
+  font-size: 0.78rem;
+  overflow-y: auto;
 }
 
 .matchupsContainer {
@@ -479,6 +663,10 @@ nav {
   box-shadow:
     0 20px 44px rgba(0, 0, 0, 0.32),
     0 2px 10px rgba(0, 0, 0, 0.22);
+}
+
+.form {
+  margin: 0;
 }
 
 .gridLayout {
@@ -577,38 +765,53 @@ nav {
   .lobbyClass {
     position: fixed;
     top: 0px;
-    bottom: 110px;
+    bottom: var(--sticky-footer-height, 80px);
     overflow-y: hidden;
   }
 
   .form {
-    min-height: 100%;
+    height: 100%;
+    width: 100%;
+    margin: 0;
     overflow-y: hidden;
     display: flex;
+    flex-direction: column;
   }
 
   .gridLayout {
-    gap: 0.5em;
+    column-gap: 0.5em;
+    row-gap: 0.15em;
     padding: 0.5em;
-    min-height: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
     overflow-y: hidden;
     display: grid;
-    grid-template-columns: 1fr 2fr 260px;
-    grid-template-rows: 240px 1fr;
+    grid-template-columns: 180px 1fr 360px;
+    grid-template-rows: 120px 1fr;
     grid-template-areas:
-      'hero weapons matchups'
+      'chat heroes matchups'
       'chat weapons matchups';
+    transition: grid-template-columns 0.25s ease;
   }
 
   .gridLayout.noMatchups {
-    grid-template-columns: 1fr 2fr 0px;
+    grid-template-columns: 180px 1fr 0px;
     grid-template-areas:
-      'hero weapons'
+      'chat heroes'
       'chat weapons';
   }
 
+  .gridLayout.chatExpanded {
+    grid-template-columns: 380px 1fr 0px;
+    grid-template-areas:
+      'chat heroes matchups'
+      'chat weapons matchups';
+  }
+
   .titleContainer {
-    grid-area: hero;
+    grid-area: heroes;
+    position: relative;
+    top: auto;
   }
 }
 

--- a/src/routes/game/lobby/Lobby.tsx
+++ b/src/routes/game/lobby/Lobby.tsx
@@ -1356,7 +1356,6 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
                 onMatchupSelected={setSelectedMatchupId}
                 isAutoApplyingMatchup={isAutoApplyingMatchup}
                 onExpandChat={isWideScreen ? () => setChatExpanded(true) : undefined}
-                format={data.format}
                 isBazaarDeck={isBazaarDeckInLobby}
               />
             )}

--- a/src/routes/game/lobby/Lobby.tsx
+++ b/src/routes/game/lobby/Lobby.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { usePageTitle } from 'hooks/usePageTitle';
+import { parseHtmlToReactElements } from 'utils/ParseEscapedString';
 import Deck from './components/deck/Deck';
 import LobbyChat from './components/lobbyChat/LobbyChat';
+import { CHAT_WHEEL } from 'constants/chatMessages';
+import { useSendGameChat } from 'hooks/useSendGameChat';
 import Calculator from './components/calculator/Calculator';
 import testData from './mockdata.json';
 import styles from './Lobby.module.css';
@@ -70,6 +73,15 @@ import { IS_STREAMER_MODE } from 'features/options/constants';
 
 const FAB_BAZAAR_LEARN_MORE_URL = 'https://fabbazaar.app/tutorials/talishar';
 
+const LOBBY_PRESETS = [
+  { id: 1,  label: 'Hello' },
+  { id: 2,  label: 'GLHF' },
+  { id: 4,  label: 'BRB' },
+  { id: 5,  label: 'Undo?' },
+  { id: 7,  label: 'No prob!' },
+  { id: 20, label: 'Chat?' },
+];
+
 const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
   if (!deckLink) return null;
   const normalizedBase = FAB_BAZAAR_DECK_URL_BASE.endsWith('/')
@@ -99,7 +111,9 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
   );
   const [isAutoApplyingMatchup, setIsAutoApplyingMatchup] =
     useState<boolean>(false);
+  const [chatExpanded, setChatExpanded] = useState(false);
   const lastAutoAppliedMatchupKey = useRef<string>('');
+  const { sendQuickChat } = useSendGameChat();
   const submittedMatchupRef = useRef<string | null>(null);
   const deckLinkTrackingRef = useRef<{ link: string | undefined; gameKey: string }>({
     link: undefined,
@@ -984,7 +998,8 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
           <FormikDebugLogger />
           <div
             className={classNames(styles.gridLayout, {
-              [styles.noMatchups]: !hasMatchups
+              [styles.noMatchups]: !hasMatchups,
+              [styles.chatExpanded]: chatExpanded && isWideScreen && hasMatchups,
             })}
           >
             <div className={styles.titleContainer}>
@@ -1208,7 +1223,7 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
                       </button>
                     </li>
                   </ul>
-                  <div style={{ marginLeft: 'auto' }}>
+                  <div style={{ marginLeft: '1rem' }}>
                     <DesktopDeckSelectionButtons
                       deckIndexed={deckIndexed}
                       deckSBIndexed={deckSBIndexed}
@@ -1275,19 +1290,56 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
                     : styles.chatAreaContainer
                 }
               >
-                <>{showCalculator ? <Calculator /> : <LobbyChat />}</>
-                <button
-                  className={classNames(styles.smallButton, {
-                    [styles.active]: showCalculator
-                  })}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    toggleShowCalculator();
-                  }}
-                  disabled={false}
-                >
-                  Hand Draw Probabilities
-                </button>
+                {isWideScreen && !chatExpanded && hasMatchups ? (
+                  <div className={styles.compactChat}>
+                    <div className={styles.compactChatHeader}>Chat</div>
+                    <MiniChatLog />
+                    <div className={styles.quickChatStrip}>
+                      {LOBBY_PRESETS.map(({ id, label }) => (
+                        <button
+                          key={id}
+                          type="button"
+                          className={styles.quickChatChip}
+                          onClick={() => sendQuickChat(CHAT_WHEEL.get(id) ?? '')}
+                        >
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                    <button
+                      type="button"
+                      className={styles.chatExpandBtn}
+                      onClick={() => setChatExpanded(true)}
+                    >
+                      Open Chat ▸
+                    </button>
+                  </div>
+                ) : (
+                  <>
+                    {isWideScreen && hasMatchups && (
+                      <button
+                        type="button"
+                        className={styles.chatToggleBtn}
+                        onClick={() => setChatExpanded(false)}
+                      >
+                        ◂ Matchups
+                      </button>
+                    )}
+                    <>{showCalculator ? <Calculator /> : <LobbyChat />}</>
+                    <button
+                      className={classNames(styles.smallButton, {
+                        [styles.active]: showCalculator
+                      })}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        toggleShowCalculator();
+                      }}
+                      disabled={false}
+                    >
+                      Hand Draw Probabilities
+                    </button>
+                  </>
+                )}
               </div>
             )}
 
@@ -1297,12 +1349,15 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
 
             <div className={styles.spacer}></div>
 
-            {shouldShowMatchupsUI && (activeTab === 'matchups' || isWideScreen) && (
+            {shouldShowMatchupsUI && (activeTab === 'matchups' || (isWideScreen && !chatExpanded)) && (
               <Matchups
                 refetch={refetch}
                 selectedMatchupId={selectedMatchupId}
                 onMatchupSelected={setSelectedMatchupId}
                 isAutoApplyingMatchup={isAutoApplyingMatchup}
+                onExpandChat={isWideScreen ? () => setChatExpanded(true) : undefined}
+                format={data.format}
+                isBazaarDeck={isBazaarDeckInLobby}
               />
             )}
             <StickyFooter
@@ -1352,6 +1407,31 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
   );
 };
 
+const COMPACT_CHAT_RE = /<span[^>]*>(.*?):\s<\/span>/;
+
+const MiniChatLog = () => {
+  const chatLog = useAppSelector((state: RootState) => state.game.chatLog);
+  const chatMessages = (chatLog ?? []).filter((m) => COMPACT_CHAT_RE.test(m));
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [chatMessages.length]);
+
+  return (
+    <div className={styles.compactChatLog}>
+      {chatMessages.length === 0 ? (
+        <span className={styles.compactChatEmpty}>No messages yet</span>
+      ) : (
+        chatMessages.map((msg, i) => (
+          <div key={i}>{parseHtmlToReactElements(msg)}</div>
+        ))
+      )}
+      <div ref={bottomRef} />
+    </div>
+  );
+};
+
 const FormikDebugLogger = () => {
   const { submitCount, isValid, errors, values, isSubmitting } =
     useFormikContext<DeckResponse>();
@@ -1385,7 +1465,7 @@ const DesktopDeckSelectionButtons = ({
   deckSBIndexed,
   activeTab,
   filtersExpanded,
-  setFiltersExpanded
+  setFiltersExpanded,
 }: {
   deckIndexed: string[];
   deckSBIndexed: string[];

--- a/src/routes/game/lobby/components/equipment/Equipment.module.css
+++ b/src/routes/game/lobby/components/equipment/Equipment.module.css
@@ -8,6 +8,8 @@
   gap: 0.5em 3em;
   padding: 0 1em;
   min-width: 0px;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 

--- a/src/routes/game/lobby/components/lobbyChat/LobbyChat.module.css
+++ b/src/routes/game/lobby/components/lobbyChat/LobbyChat.module.css
@@ -3,11 +3,11 @@
   flex-direction: column;
   align-content: center;
   justify-content: flex-end;
-  align-items: flex-end;
+  align-items: stretch;
   max-width: 100%;
   min-width: 0px;
-  grid-area: chat;
-  height: calc(100dvh - 440px);
+  flex: 1;
+  min-height: 0;
 }
 
 .spacer {
@@ -18,6 +18,7 @@
   .container {
     height: calc(100dvh - 380px);
     min-height: 200px;
+    flex: 0 0 auto;
   }
 
   .spacer {

--- a/src/routes/game/lobby/components/matchups/Matchups.module.css
+++ b/src/routes/game/lobby/components/matchups/Matchups.module.css
@@ -1,72 +1,239 @@
 .matchupContainer {
-  margin: 0 auto;
-  height: auto;
   display: flex;
-  width: 100%;
-  max-width: 260px;
-  align-items: center;
-  justify-content: flex-start;
   flex-direction: column;
-  overflow-y: auto;
+  width: 100%;
+  max-width: 360px;
   grid-area: matchups;
   overflow-x: hidden;
   background: transparent;
-  padding: 0.75rem 0.5rem;
-  gap: 0.25rem;
+  margin: 0;
+  padding: 0.75rem 0.6rem;
+  gap: 0.4rem;
   position: relative;
   z-index: 1001;
-  max-height: calc(100vh - 120px);
+  min-height: 0;
+  height: 100%;
   overflow-y: auto;
 }
 
+.matchupHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+}
+
 .matchupContainer h4 {
-  margin: 0 0 0.5rem 0;
-  font-size: 1.1rem;
+  margin: 0;
+  font-size: 1rem;
   font-weight: 600;
   letter-spacing: 0.05em;
 }
 
-.emptyMatchupContainer {
-  margin: 0 auto;
-  height: auto;
-  display: flex;
-  width: 100px;
-  align-items: center;
-  justify-content: flex-start;
-  flex-direction: column;
-  overflow-y: auto;
-  grid-area: matchups;
-  overflow-x: hidden;
-  opacity: 0;
+.chatToggleBtn {
+  padding: 0.2rem 0.5rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.6);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  width: auto;
+  margin: 0;
 }
 
-.matchups {
+.chatToggleBtn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.9);
+  border-color: rgba(255, 255, 255, 0.3);
+  transform: none;
+  box-shadow: none;
+}
+
+.searchInput {
   width: 100%;
-  position: relative;
+  margin-bottom: 0.25rem;
 }
 
-.matchupButton {
+.groupsWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.classGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.groupHeader {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.65);
+  margin: 0;
+  padding-left: 0.1rem;
+}
+
+.portraitGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.35rem;
+}
+
+.namedMatchupList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.namedMatchupItem {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.88);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.matchupButtonSelected {
-  background-color: var(--theme-secondary, #606569) !important;
-  border-color: var(--theme-secondary-hover, #757a7f) !important;
-  color: var(--theme-secondary-inverse, #ffffff) !important;
-  box-shadow: 0 0 0 2px var(--theme-primary, #d4af37) inset;
+.namedMatchupItem:hover {
+  background: rgba(217, 184, 74, 0.1);
+  border-color: rgba(217, 184, 74, 0.45);
+  color: #f0d070;
 }
 
-.selectedBadge {
+.namedMatchupItem:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.namedMatchupSelected {
+  background: rgba(217, 184, 74, 0.15);
+  border-color: rgba(217, 184, 74, 0.75);
+  color: #f0d070;
+}
+
+.namedMatchupName {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.namedMatchupBadge {
+  flex-shrink: 0;
+  padding: 0.12rem 0.45rem;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: rgba(217, 184, 74, 0.95);
+  background: rgba(217, 184, 74, 0.15);
+  border: 1px solid rgba(217, 184, 74, 0.4);
+  border-radius: 999px;
+}
+
+.portraitCard {
+  position: relative;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 2px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  aspect-ratio: 3 / 4;
+  transition: border-color 0.15s ease, transform 0.1s ease;
+  width: 100%;
+}
+
+.portraitCard:hover {
+  border-color: rgba(255, 255, 255, 0.4);
+  transform: translateY(-1px);
+}
+
+.portraitCard:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.portraitCardSelected {
+  border-color: #4a9eff !important;
+  box-shadow: 0 0 0 1px #4a9eff;
+}
+
+.portraitImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center top;
+  display: block;
+  filter: grayscale(100%);
+  transition: filter 0.15s ease;
+}
+
+.portraitImgHasData {
+  filter: grayscale(0%);
+}
+
+.portraitCard:hover .portraitImg {
+  filter: grayscale(60%);
+}
+
+.portraitCard:hover .portraitImgHasData {
+  filter: grayscale(0%);
+}
+
+.portraitCardSelected .portraitImg {
+  filter: grayscale(0%);
+}
+
+.portraitOverlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0.6rem 0.4rem 0.3rem;
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.85));
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.portraitName {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+
+.turnOrderBadge {
   font-size: 0.6rem;
   font-weight: 700;
   letter-spacing: 0.06em;
-  border-radius: 0.35rem;
-  padding: 0.16rem 0.34rem;
-  background: rgba(0, 0, 0, 0.35);
-  color: #fff;
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  background: rgba(212, 175, 55, 0.2);
+  color: var(--theme-primary, #d4af37);
+  border: 1px solid rgba(212, 175, 55, 0.4);
+  width: fit-content;
 }
 
 .autoApplyingStatus {
@@ -77,208 +244,130 @@
   opacity: 0.9;
 }
 
-.matchups button {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  width: 100%;
-  padding: 0.5rem 0.75rem;
-  background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 6px;
-  color: rgba(255, 255, 255, 0.85);
-  font-weight: 400;
-  font-size: 0.875rem;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  position: relative;
-  overflow: visible;
-  margin-bottom: 0;
-}
-
-.matchups button:hover {
-  background: rgba(255, 255, 255, 0.05);
-  border-color: var(--theme-primary, #d4af37);
-  color: #fff;
-  transform: none;
-}
-
-.matchups button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  transform: none;
-}
-
-.matchups button:active {
-  background: rgba(255, 255, 255, 0.08);
-  transform: none;
-}
-
-.matchupName {
-  text-align: left;
-  font-weight: 400;
-  color: inherit;
-  flex: 1;
-  min-width: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.turnOrderBadge {
-  font-size: 0.6rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  padding: 0.15rem 0.35rem;
-  border-radius: 3px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  background: rgba(212, 175, 55, 0.15);
-  color: var(--theme-primary, #d4af37);
-  border: 1px solid rgba(212, 175, 55, 0.3);
-  box-shadow: none;
-  min-width: 2.2rem;
-  width: 2.2rem;
-  margin-left: auto;
-}
-
-/* Tablet: 3 columns, uniform sizing */
-@media (max-width: 1200px) and (min-width: 769px) {
+/* Tablet and below: horizontal scrolling strip */
+@media (max-width: 1200px) {
   .matchupContainer {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
     max-width: 100%;
-    padding: 0.75rem 0.5rem;
-    gap: 0.5rem;
-    height: auto;
+    padding: 0.5rem;
+    flex-direction: column;
     max-height: calc(100vh - var(--sticky-footer-height, 80px) - 130px - 120px);
-    overflow-y: auto;
   }
 
-  .matchupContainer h4 {
-    display: none;
-  }
-
-  .matchups {
-    width: 100%;
-  }
-
-  .matchups button {
-    padding: 0.45rem 0.5rem;
-    font-size: 0.75rem;
-    margin-bottom: 0;
-    flex-direction: row;
-    gap: 0.4rem;
-    height: auto;
-    min-height: unset;
-  }
-
-  .matchupName {
-    text-align: left;
-    width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: 0.85em;
-  }
-
-  .turnOrderBadge {
-    min-width: unset;
-    flex-shrink: 0;
+  .portraitGrid {
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 
-/* Mobile: 2-column grid, uniform sizing */
 @media (max-width: 768px) {
-  .matchupContainer {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    max-width: 100%;
-    width: 100%;
-    padding: 0.75rem 0.5rem;
-    gap: 0.4rem;
-    height: auto;
-    max-height: calc(100vh - var(--sticky-footer-height, 80px) - 130px - 120px);
-    overflow-y: auto;
-  }
-
-  .matchupContainer h4 {
-    display: none;
-  }
-
-  .matchupContainer input[type='text'] {
-    grid-column: 1 / -1;
-    margin-bottom: 0.25rem;
-  }
-
-  .matchups {
-    width: 100%;
-  }
-
-  .matchups button {
-    padding: 0.45rem 0.5rem;
-    font-size: 0.8rem;
-    margin-bottom: 0;
-    flex-direction: row;
-    gap: 0.4rem;
-    height: auto;
-    min-height: unset;
-  }
-
-  .matchupName {
-    text-align: left;
-    width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: 0.85em;
-  }
-
-  .turnOrderBadge {
-    font-size: 0.6rem;
-    padding: 0.1rem 0.25rem;
-    min-width: unset;
-    flex-shrink: 0;
+  .portraitGrid {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 
-/* Small mobile: 2 columns with fixed height */
-@media (max-width: 480px) {
-  .matchupContainer {
-    grid-template-columns: repeat(2, 1fr);
-    padding: 0.5rem 0.4rem;
-    gap: 0.3rem;
-  }
+.noDataBackdrop {
+  position: fixed;
+  inset: 0;
+  background: transparent;
+  z-index: 9999;
+}
 
-  .matchupContainer h4 {
-    display: none;
-  }
+.noDataPopover {
+  position: fixed;
+  width: 260px;
+  background: linear-gradient(180deg, #242b34 0%, #1a1f25 100%);
+  border: 1px solid rgba(217, 184, 74, 0.4);
+  border-radius: 10px;
+  padding: 0.7rem 0.85rem 0.75rem;
+  box-shadow:
+    0 12px 36px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset;
+  z-index: 10000;
+  animation: noDataPopIn 0.14s cubic-bezier(0.2, 0.8, 0.3, 1.1);
+}
 
-  .matchupContainer input[type='text'] {
-    grid-column: 1 / -1;
-    margin-bottom: 0.25rem;
-  }
+@keyframes noDataPopIn {
+  from { opacity: 0; transform: translateY(-50%) scale(0.94); }
+  to   { opacity: 1; transform: translateY(-50%) scale(1); }
+}
 
-  .matchups button {
-    padding: 0.4rem 0.4rem;
-    font-size: 0.8rem;
-    gap: 0.3rem;
-    height: auto;
-    min-height: unset;
-  }
+.noDataPopover::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  background: #1f252d;
+  border: 1px solid rgba(217, 184, 74, 0.4);
+  transform: translateY(-50%) rotate(45deg);
+}
 
-  .matchupName {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: 0.85em;
-  }
+.noDataPopover[data-placement="left"]::before {
+  right: -6px;
+  border-top: none;
+  border-left: none;
+}
 
-  .turnOrderBadge {
-    font-size: 0.55rem;
-    padding: 0.1rem 0.2rem;
-  }
+.noDataPopover[data-placement="right"]::before {
+  left: -6px;
+  border-bottom: none;
+  border-right: none;
+}
+
+.noDataCloseX {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.12s ease, color 0.12s ease;
+  margin: 0;
+}
+
+.noDataCloseX:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.noDataTitle {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #f0d070;
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.02em;
+  padding-right: 1rem;
+}
+
+.noDataBody {
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.78);
+  margin: 0 0 0.5rem;
+}
+
+.noDataBody strong {
+  color: rgba(255, 255, 255, 0.95);
+  font-weight: 600;
+}
+
+.noDataLearnLink {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #d9b84a;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.noDataLearnLink:hover {
+  color: #f0d070;
+  text-decoration: underline;
 }

--- a/src/routes/game/lobby/components/matchups/Matchups.tsx
+++ b/src/routes/game/lobby/components/matchups/Matchups.tsx
@@ -25,43 +25,11 @@ export interface Matchups {
   isBazaarDeck?: boolean;
 }
 
-const HERO_CLASS_MAP: Record<string, string> = {
-  Arakni: 'Assassin', Uzuri: 'Assassin', Nuu: 'Assassin',
-  Bravo: 'Guardian', Oldhim: 'Guardian', Betsy: 'Guardian', Victor: 'Guardian',
-  Jarl: 'Guardian', Valda: 'Guardian', Lyath: 'Guardian', Pleiades: 'Guardian',
-  Genis: 'Guardian', Brevant: 'Guardian', Terra: 'Guardian',
-  Rhinar: 'Brute', Levia: 'Brute', Kayo: 'Brute', Tuffnut: 'Brute',
-  Katsu: 'Ninja', Ira: 'Ninja', Benji: 'Ninja', Fai: 'Ninja',
-  Emperor: 'Ninja', Fang: 'Ninja',
-  Dorinthea: 'Warrior', Boltyn: 'Warrior', Kassai: 'Warrior', Ser: 'Warrior',
-  Olympia: 'Warrior', Yoji: 'Warrior', Hala: 'Warrior',
-  Briar: 'Runeblade', Chane: 'Runeblade', Viserai: 'Runeblade',
-  Blasmophet: 'Runeblade', Vynnset: 'Runeblade', Dromai: 'Runeblade', Cindra: 'Runeblade',
-  Prism: 'Illusionist', Enigma: 'Illusionist', Aurora: 'Illusionist',
-  Kano: 'Wizard', Iyslander: 'Wizard', Blaze: 'Wizard',
-  Dash: 'Mechanologist', Maxx: 'Mechanologist', Teklovossen: 'Mechanologist',
-  Puffin: 'Mechanologist', Data: 'Mechanologist', Professor: 'Mechanologist',
-  Azalea: 'Ranger', Gorganian: 'Ranger', Lexi: 'Ranger', Riptide: 'Ranger',
-  Gravy: 'Pirate', Anothos: 'Pirate', Marlynn: 'Pirate', Scurv: 'Pirate',
-  Florian: 'Necromancer', Verdance: 'Necromancer', Oscilio: 'Necromancer',
-};
-
-const CLASS_ORDER = [
-  'Assassin', 'Brute', 'Guardian', 'Illusionist',
-  'Mechanologist', 'Necromancer', 'Ninja', 'Pirate',
-  'Ranger', 'Runeblade', 'Warrior', 'Wizard', 'Other',
-];
-
 const BLITZ_FORMATS = new Set([
   GAME_FORMAT.BLITZ, GAME_FORMAT.COMPETITIVE_BLITZ, GAME_FORMAT.OPEN_BLITZ,
   GAME_FORMAT.SAGE, GAME_FORMAT.COMPETITIVE_SAGE, GAME_FORMAT.OPEN_SAGE,
   GAME_FORMAT.COMMONER,
 ]);
-
-const getHeroClass = (name: string): string => {
-  const firstName = name.split(/[\s,]/)[0];
-  return HERO_CLASS_MAP[firstName] ?? 'Other';
-};
 
 const Matchups = ({
   refetch,
@@ -264,18 +232,25 @@ const Matchups = ({
     [unsavedHeroes, searchTerm]
   );
 
+  // Group by backend-supplied class (e.g. "RUNEBLADE" -> "Runeblade").
+  // When the backend hasn't shipped legalHeroes (fallback path), `class` is
+  // empty and everything buckets under "Other" — still functional, just less
+  // organized until the backend ships.
   const groupedMatchups = useMemo(() => {
     const groups: Record<string, typeof filteredUnsavedHeroes> = {};
     for (const h of filteredUnsavedHeroes) {
-      // Prefer backend-supplied class; fall back to first-name HERO_CLASS_MAP
       const cls = h.class
-        ? h.class.charAt(0) + h.class.slice(1).toLowerCase() // "RUNEBLADE" -> "Runeblade"
-        : getHeroClass(h.name);
+        ? h.class.charAt(0) + h.class.slice(1).toLowerCase()
+        : 'Other';
       if (!groups[cls]) groups[cls] = [];
       groups[cls].push(h);
     }
-    return CLASS_ORDER
-      .filter((cls) => groups[cls]?.length)
+    return Object.keys(groups)
+      .sort((a, b) => {
+        if (a === 'Other') return 1;
+        if (b === 'Other') return -1;
+        return a.localeCompare(b);
+      })
       .map((cls) => ({ cls, matchups: groups[cls] }));
   }, [filteredUnsavedHeroes]);
 

--- a/src/routes/game/lobby/components/matchups/Matchups.tsx
+++ b/src/routes/game/lobby/components/matchups/Matchups.tsx
@@ -1,48 +1,91 @@
 import { useAppSelector } from 'app/Hooks';
 import { RootState } from 'app/Store';
+import { GAME_FORMAT } from 'appConstants';
 import { useJoinGameMutation } from 'features/api/apiSlice';
 import { getGameInfo } from 'features/game/GameSlice';
-import React, { useState } from 'react';
+import { Matchup, LegalHero } from 'interface/API/GetLobbyRefresh.php';
+import React, { useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { toast } from 'react-hot-toast';
 import { shallowEqual } from 'react-redux';
+import { HEROES_OF_RATHE } from 'routes/index/components/filter/constants';
+import { generateCroppedImageUrl } from 'utils/cropImages';
 import styles from './Matchups.module.css';
 import MatchupTooltip from './MatchupTooltip';
+
+const FAB_BAZAAR_LEARN_MORE_URL = 'https://fabbazaar.app/tutorials/talishar';
 
 export interface Matchups {
   refetch: () => void;
   selectedMatchupId?: string | null;
   onMatchupSelected?: (matchupId: string) => void;
   isAutoApplyingMatchup?: boolean;
+  onExpandChat?: () => void;
+  format?: string;
+  isBazaarDeck?: boolean;
 }
+
+const HERO_CLASS_MAP: Record<string, string> = {
+  Arakni: 'Assassin', Uzuri: 'Assassin', Nuu: 'Assassin',
+  Bravo: 'Guardian', Oldhim: 'Guardian', Betsy: 'Guardian', Victor: 'Guardian',
+  Jarl: 'Guardian', Valda: 'Guardian', Lyath: 'Guardian', Pleiades: 'Guardian',
+  Genis: 'Guardian', Brevant: 'Guardian', Terra: 'Guardian',
+  Rhinar: 'Brute', Levia: 'Brute', Kayo: 'Brute', Tuffnut: 'Brute',
+  Katsu: 'Ninja', Ira: 'Ninja', Benji: 'Ninja', Fai: 'Ninja',
+  Emperor: 'Ninja', Fang: 'Ninja',
+  Dorinthea: 'Warrior', Boltyn: 'Warrior', Kassai: 'Warrior', Ser: 'Warrior',
+  Olympia: 'Warrior', Yoji: 'Warrior', Hala: 'Warrior',
+  Briar: 'Runeblade', Chane: 'Runeblade', Viserai: 'Runeblade',
+  Blasmophet: 'Runeblade', Vynnset: 'Runeblade', Dromai: 'Runeblade', Cindra: 'Runeblade',
+  Prism: 'Illusionist', Enigma: 'Illusionist', Aurora: 'Illusionist',
+  Kano: 'Wizard', Iyslander: 'Wizard', Blaze: 'Wizard',
+  Dash: 'Mechanologist', Maxx: 'Mechanologist', Teklovossen: 'Mechanologist',
+  Puffin: 'Mechanologist', Data: 'Mechanologist', Professor: 'Mechanologist',
+  Azalea: 'Ranger', Gorganian: 'Ranger', Lexi: 'Ranger', Riptide: 'Ranger',
+  Gravy: 'Pirate', Anothos: 'Pirate', Marlynn: 'Pirate', Scurv: 'Pirate',
+  Florian: 'Necromancer', Verdance: 'Necromancer', Oscilio: 'Necromancer',
+};
+
+const CLASS_ORDER = [
+  'Assassin', 'Brute', 'Guardian', 'Illusionist',
+  'Mechanologist', 'Necromancer', 'Ninja', 'Pirate',
+  'Ranger', 'Runeblade', 'Warrior', 'Wizard', 'Other',
+];
+
+const BLITZ_FORMATS = new Set([
+  GAME_FORMAT.BLITZ, GAME_FORMAT.COMPETITIVE_BLITZ, GAME_FORMAT.OPEN_BLITZ,
+  GAME_FORMAT.SAGE, GAME_FORMAT.COMPETITIVE_SAGE, GAME_FORMAT.OPEN_SAGE,
+  GAME_FORMAT.COMMONER,
+]);
+
+const getHeroClass = (name: string): string => {
+  const firstName = name.split(/[\s,]/)[0];
+  return HERO_CLASS_MAP[firstName] ?? 'Other';
+};
 
 const Matchups = ({
   refetch,
   selectedMatchupId,
   onMatchupSelected,
-  isAutoApplyingMatchup = false
+  isAutoApplyingMatchup = false,
+  onExpandChat,
+  format,
+  isBazaarDeck = false,
 }: Matchups) => {
   const [isUpdating, setIsUpdating] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+  const [noDataHero, setNoDataHero] = useState<{
+    id: string;
+    name: string;
+    anchorRect: DOMRect;
+  } | null>(null);
 
   const gameLobby = useAppSelector(
     (state: RootState) => state.game.gameLobby,
     shallowEqual
   );
   const { gameID, playerID } = useAppSelector(getGameInfo, shallowEqual);
-  const [joinGameMutation, joinGameMutationData] = useJoinGameMutation();
-
-  const getTurnOrderIndicator = (
-    preferredTurnOrder: string | null | undefined
-  ) => {
-    if (!preferredTurnOrder) return null;
-
-    if (preferredTurnOrder === '1st') {
-      return '1st';
-    } else if (preferredTurnOrder === '2nd') {
-      return '2nd';
-    }
-    return null;
-  };
+  const [joinGameMutation] = useJoinGameMutation();
 
   const handleMatchupClick = async (matchupID: string) => {
     setIsUpdating(true);
@@ -67,66 +110,439 @@ const Matchups = ({
     }
   };
 
-  const sortedMatchups = [...(gameLobby?.matchups ?? [])];
-  sortedMatchups.sort((a, b) => a.name.localeCompare(b.name));
+  // Universe of all known heroes — used for resolveHero() so we can identify
+  // a saved matchup as hero-backed even when the hero is banned in the current
+  // format (e.g. Verdance saved against a CC deck → still recognized as a hero
+  // even though Verdance is a Living Legend banned in CC). Always sources from
+  // HEROES_OF_RATHE; backend's legalHeroes is layered on top to attach the
+  // class string when available.
+  const HERO_BY_NAME = useMemo(() => {
+    const map = new Map<string, { id: string; name: string; class: string }>();
+    for (const h of HEROES_OF_RATHE) {
+      map.set(h.label.toLowerCase(), { id: h.value, name: h.label, class: '' });
+    }
+    // Layer in backend data when present — gives us the class string and the
+    // slug-style id (vs. HEROES_OF_RATHE's card-ID style).
+    for (const h of gameLobby?.legalHeroes ?? []) {
+      map.set(h.name.toLowerCase(), { id: h.heroId, name: h.name, class: h.class });
+    }
+    return map;
+  }, [gameLobby?.legalHeroes]);
 
-  const filteredMatchups = sortedMatchups.filter((matchup) =>
-    matchup.name.toLowerCase().includes(searchTerm.toLowerCase())
+  const HERO_BY_ID = useMemo(() => {
+    const map = new Map<string, { id: string; name: string; class: string }>();
+    // Card-ID keyed (e.g. "DYN113")
+    for (const h of HEROES_OF_RATHE) {
+      map.set(h.value, { id: h.value, name: h.label, class: '' });
+    }
+    // Slug-keyed from backend (e.g. "arakni_huntsman") — overrides where present
+    for (const h of gameLobby?.legalHeroes ?? []) {
+      map.set(h.heroId, { id: h.heroId, name: h.name, class: h.class });
+    }
+    return map;
+  }, [gameLobby?.legalHeroes]);
+
+  // Resolve a saved matchup to a hero entry if it conceptually targets one.
+  // First try matchupId (slug or card ID), then the matchup's display name.
+  const resolveHero = (m: { matchupId: string; name?: string | null }) => {
+    return (
+      HERO_BY_ID.get(m.matchupId) ??
+      (m.name ? HERO_BY_NAME.get(m.name.toLowerCase()) : undefined) ??
+      null
+    );
+  };
+
+  // Partition saved matchups into hero-backed (rendered as portrait) vs
+  // custom-named (rendered as full-width button).
+  //
+  // When the backend provides `legalHeroes`, that list is authoritative —
+  // hero matchups for heroes NOT in the legal list (e.g. saved against a
+  // Living Legend then loaded into a CC deck) are dropped entirely. This
+  // protects against deckbuilders that don't validate format bans on their
+  // side. When the backend hasn't sent `legalHeroes`, all hero matchups
+  // are shown (no ban data available to filter on).
+  const { savedHeroMatchups, customMatchups } = useMemo(() => {
+    const heroes: { hero: { id: string; name: string; class: string }; matchup: Matchup }[] = [];
+    const customs: Matchup[] = [];
+
+    const legalList = gameLobby?.legalHeroes;
+    const legalSet =
+      legalList && legalList.length > 0
+        ? new Set<string>([
+            ...legalList.map((h) => h.heroId),
+            ...legalList.map((h) => h.name.toLowerCase()),
+          ])
+        : null;
+
+    for (const m of gameLobby?.matchups ?? []) {
+      const hero = resolveHero(m);
+      if (hero) {
+        if (legalSet) {
+          const isLegal =
+            legalSet.has(m.matchupId) ||
+            (m.name ? legalSet.has(m.name.toLowerCase()) : false);
+          if (!isLegal) continue; // banned hero in this format — drop entirely
+        }
+        heroes.push({ hero, matchup: m });
+      } else {
+        customs.push(m);
+      }
+    }
+    return { savedHeroMatchups: heroes, customMatchups: customs };
+  }, [gameLobby?.matchups, gameLobby?.legalHeroes, HERO_BY_ID, HERO_BY_NAME]);
+
+  // Format-legal heroes that AREN'T already saved (the discovery grid for Bazaar).
+  // Non-Bazaar decks don't show this section at all.
+  // When the backend sent `legalHeroes`, that list is already ban-filtered and
+  // format-filtered. Otherwise we fall back to HEROES_OF_RATHE + young flag.
+  const unsavedHeroes = useMemo(() => {
+    if (!isBazaarDeck) return [];
+    const savedHeroIds = new Set(savedHeroMatchups.map((s) => s.hero.id));
+    const fromBackend = gameLobby?.legalHeroes;
+    if (fromBackend && fromBackend.length > 0) {
+      return fromBackend
+        .filter((h) => !savedHeroIds.has(h.heroId))
+        .map((h) => ({
+          matchupId: h.heroId,
+          name: h.name,
+          class: h.class,
+          preferredTurnOrder: null as string | null,
+          notes: null as string | null,
+          hasData: false,
+        }));
+    }
+    // Fallback: derive from FE constants (NO ban filter — heroes that are banned
+    // in the current format will incorrectly appear)
+    const useYoung = format ? BLITZ_FORMATS.has(format) : false;
+    return HEROES_OF_RATHE
+      .filter((h) => !!h.young === useYoung)
+      .filter((h) => !savedHeroIds.has(h.value))
+      .map((h) => ({
+        matchupId: h.value,
+        name: h.label,
+        class: '',
+        preferredTurnOrder: null as string | null,
+        notes: null as string | null,
+        hasData: false,
+      }));
+  }, [format, savedHeroMatchups, isBazaarDeck, gameLobby?.legalHeroes]);
+
+  const matchesSearch = (s: string) =>
+    s.toLowerCase().includes(searchTerm.toLowerCase());
+
+  // When the opponent's hero is known, sort the saved hero matchups so the one
+  // targeting that hero is first (upper-left). Subsequent ordering is preserved.
+  const sortedSavedHeroMatchups = useMemo(() => {
+    const theirHero = gameLobby?.theirHero?.toLowerCase();
+    if (!theirHero || theirHero === 'cardback') return savedHeroMatchups;
+    const idx = savedHeroMatchups.findIndex(
+      ({ matchup, hero }) =>
+        matchup.matchupId.toLowerCase() === theirHero ||
+        hero.id.toLowerCase() === theirHero
+    );
+    if (idx <= 0) return savedHeroMatchups; // not found, or already first
+    const reordered = [...savedHeroMatchups];
+    const [match] = reordered.splice(idx, 1);
+    reordered.unshift(match);
+    return reordered;
+  }, [savedHeroMatchups, gameLobby?.theirHero]);
+
+  const filteredSavedHeroMatchups = useMemo(
+    () => sortedSavedHeroMatchups.filter(({ matchup, hero }) =>
+      matchesSearch(matchup.name ?? hero.name)
+    ),
+    [sortedSavedHeroMatchups, searchTerm]
   );
 
-  if (sortedMatchups.length > 0) {
-    return (
-      <article className={styles.matchupContainer}>
-        <>
-          <h4>Matchups</h4>
-          <input
-            type="text"
-            placeholder="Search"
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-          />
-          {filteredMatchups.map((matchup, ix) => {
-            const turnOrderIndicator = getTurnOrderIndicator(
-              matchup.preferredTurnOrder
-            );
-            return (
-              <div className={styles.matchups} key={ix}>
-                <MatchupTooltip content={matchup.notes}>
-                  <button
-                    disabled={isUpdating}
-                    className={`${styles.matchupButton} ${
-                      selectedMatchupId === matchup.matchupId
-                        ? styles.matchupButtonSelected
-                        : 'outline'
-                    }`}
-                    onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                      e.preventDefault();
-                      handleMatchupClick(matchup.matchupId);
-                    }}
-                  >
-                    <span className={styles.matchupName}>{matchup.name}</span>
-                    {selectedMatchupId === matchup.matchupId && (
-                      <span className={styles.selectedBadge}>Selected</span>
-                    )}
-                    {turnOrderIndicator && (
-                      <span className={styles.turnOrderBadge}>
-                        {turnOrderIndicator}
-                      </span>
-                    )}
-                  </button>
-                </MatchupTooltip>
+  const filteredCustomMatchups = useMemo(
+    () => customMatchups.filter((m) => matchesSearch(m.name ?? m.matchupId)),
+    [customMatchups, searchTerm]
+  );
+
+  const filteredUnsavedHeroes = useMemo(
+    () => unsavedHeroes.filter((h) => matchesSearch(h.name)),
+    [unsavedHeroes, searchTerm]
+  );
+
+  const groupedMatchups = useMemo(() => {
+    const groups: Record<string, typeof filteredUnsavedHeroes> = {};
+    for (const h of filteredUnsavedHeroes) {
+      // Prefer backend-supplied class; fall back to first-name HERO_CLASS_MAP
+      const cls = h.class
+        ? h.class.charAt(0) + h.class.slice(1).toLowerCase() // "RUNEBLADE" -> "Runeblade"
+        : getHeroClass(h.name);
+      if (!groups[cls]) groups[cls] = [];
+      groups[cls].push(h);
+    }
+    return CLASS_ORDER
+      .filter((cls) => groups[cls]?.length)
+      .map((cls) => ({ cls, matchups: groups[cls] }));
+  }, [filteredUnsavedHeroes]);
+
+  if ((gameLobby?.matchups ?? []).length === 0) return null;
+
+  return (
+    <article className={styles.matchupContainer}>
+      <div className={styles.matchupHeader}>
+        <h4>Matchups</h4>
+        {onExpandChat && (
+          <button
+            type="button"
+            className={styles.chatToggleBtn}
+            onClick={onExpandChat}
+          >
+            ◂ Chat
+          </button>
+        )}
+      </div>
+      <input
+        type="text"
+        placeholder="Search"
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        className={styles.searchInput}
+      />
+      {isAutoApplyingMatchup && (
+        <p className={styles.autoApplyingStatus}>Applying hero matchup...</p>
+      )}
+      <div className={styles.groupsWrapper}>
+        {(filteredSavedHeroMatchups.length > 0 || filteredCustomMatchups.length > 0) && (
+          <div className={styles.classGroup}>
+            <p className={styles.groupHeader}>SAVED PROFILES</p>
+            {filteredSavedHeroMatchups.length > 0 && (
+              <div className={styles.portraitGrid}>
+                {filteredSavedHeroMatchups.map(({ hero, matchup }) => {
+                  const isSelected = selectedMatchupId === matchup.matchupId;
+                  return (
+                    <MatchupTooltip key={matchup.matchupId} content={matchup.notes ?? null}>
+                      <button
+                        type="button"
+                        disabled={isUpdating}
+                        className={`${styles.portraitCard} ${isSelected ? styles.portraitCardSelected : ''}`}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          handleMatchupClick(matchup.matchupId);
+                        }}
+                      >
+                        <img
+                          src={generateCroppedImageUrl(hero.id)}
+                          alt={matchup.name ?? hero.name}
+                          className={`${styles.portraitImg} ${styles.portraitImgHasData}`}
+                          onError={(e) => {
+                            (e.target as HTMLImageElement).style.opacity = '0';
+                          }}
+                        />
+                        <div className={styles.portraitOverlay}>
+                          <span className={styles.portraitName}>
+                            {matchup.name ?? hero.name}
+                          </span>
+                          {matchup.preferredTurnOrder && (
+                            <span className={styles.turnOrderBadge}>
+                              {matchup.preferredTurnOrder}
+                            </span>
+                          )}
+                        </div>
+                      </button>
+                    </MatchupTooltip>
+                  );
+                })}
               </div>
-            );
-          })}
-          {isAutoApplyingMatchup && (
-            <p className={styles.autoApplyingStatus}>Applying hero matchup...</p>
-          )}
-        </>
-      </article>
-    );
+            )}
+            {filteredCustomMatchups.length > 0 && (
+              <div className={styles.namedMatchupList}>
+                {filteredCustomMatchups.map((m) => {
+                  const isSelected = selectedMatchupId === m.matchupId;
+                  return (
+                    <MatchupTooltip key={m.matchupId} content={m.notes ?? null}>
+                      <button
+                        type="button"
+                        disabled={isUpdating}
+                        className={`${styles.namedMatchupItem} ${isSelected ? styles.namedMatchupSelected : ''}`}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          handleMatchupClick(m.matchupId);
+                        }}
+                      >
+                        <span className={styles.namedMatchupName}>
+                          {m.name ?? m.matchupId}
+                        </span>
+                        {m.preferredTurnOrder && (
+                          <span className={styles.namedMatchupBadge}>
+                            {m.preferredTurnOrder}
+                          </span>
+                        )}
+                      </button>
+                    </MatchupTooltip>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+        {groupedMatchups.map(({ cls, matchups }) => (
+          <div key={cls} className={styles.classGroup}>
+            <p className={styles.groupHeader}>{cls.toUpperCase()}</p>
+            <div className={styles.portraitGrid}>
+              {matchups.map((matchup) => {
+                const isSelected = selectedMatchupId === matchup.matchupId;
+                return (
+                  <MatchupTooltip key={matchup.matchupId} content={matchup.notes}>
+                    <button
+                      type="button"
+                      disabled={isUpdating}
+                      className={`${styles.portraitCard} ${isSelected ? styles.portraitCardSelected : ''}`}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        if (!matchup.hasData) {
+                          const rect = (e.currentTarget as HTMLButtonElement).getBoundingClientRect();
+                          setNoDataHero({
+                            id: matchup.matchupId,
+                            name: matchup.name,
+                            anchorRect: rect,
+                          });
+                          return;
+                        }
+                        handleMatchupClick(matchup.matchupId);
+                      }}
+                    >
+                      <img
+                        src={generateCroppedImageUrl(matchup.matchupId)}
+                        alt={matchup.name}
+                        className={`${styles.portraitImg} ${matchup.hasData ? styles.portraitImgHasData : ''}`}
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).style.opacity = '0';
+                        }}
+                      />
+                      <div className={styles.portraitOverlay}>
+                        <span className={styles.portraitName}>{matchup.name}</span>
+                        {matchup.preferredTurnOrder && (
+                          <span className={styles.turnOrderBadge}>
+                            {matchup.preferredTurnOrder}
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  </MatchupTooltip>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+      {noDataHero &&
+        createPortal(
+          <NoDataPopover
+            hero={noDataHero}
+            onClose={() => setNoDataHero(null)}
+            deckLink={gameLobby?.myDeckLink}
+          />,
+          document.body
+        )}
+    </article>
+  );
+};
+
+const POPOVER_WIDTH = 260;
+const POPOVER_GAP = 10;
+
+const FAB_BAZAAR_DECK_PREFIX = 'https://fabbazaar.app/decks/';
+
+const buildMatchupsLink = (deckLink: string | undefined): string | null => {
+  if (!deckLink) return null;
+  // FaB Bazaar exposes a /matchups subpath; deep-link straight there so the
+  // user lands on the matchup-config page for the hero they just clicked.
+  if (deckLink.startsWith(FAB_BAZAAR_DECK_PREFIX)) {
+    const trimmed = deckLink.split('?')[0].replace(/\/+$/, '');
+    return `${trimmed}/matchups`;
+  }
+  // Other deckbuilders: just open the deck page (we don't know if/where they
+  // expose a matchups view).
+  return deckLink;
+};
+
+const NoDataPopover = ({
+  hero,
+  onClose,
+  deckLink,
+}: {
+  hero: { id: string; name: string; anchorRect: DOMRect };
+  onClose: () => void;
+  deckLink?: string;
+}) => {
+  const { anchorRect } = hero;
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  // Anchor to the left of the hero card by default; flip to right side if no room
+  let left = anchorRect.left - POPOVER_WIDTH - POPOVER_GAP;
+  let placement: 'left' | 'right' = 'left';
+  if (left < 8) {
+    left = anchorRect.right + POPOVER_GAP;
+    placement = 'right';
+  }
+  if (left + POPOVER_WIDTH > vw - 8) {
+    left = vw - POPOVER_WIDTH - 8;
   }
 
-  return null;
+  // Vertically center on the anchor, but keep within viewport
+  let top = anchorRect.top + anchorRect.height / 2;
+  const estimatedHeight = 150;
+  top = Math.max(8 + estimatedHeight / 2, Math.min(top, vh - 8 - estimatedHeight / 2));
+
+  return (
+    <>
+      <div className={styles.noDataBackdrop} onClick={onClose} />
+      <div
+        className={styles.noDataPopover}
+        style={{
+          top: `${top}px`,
+          left: `${left}px`,
+          transform: 'translateY(-50%)',
+        }}
+        data-placement={placement}
+      >
+        <button
+          type="button"
+          className={styles.noDataCloseX}
+          onClick={onClose}
+          aria-label="Close"
+        >
+          ×
+        </button>
+        <p className={styles.noDataTitle}>No matchup saved</p>
+        <p className={styles.noDataBody}>
+          No deck profile against <strong>{hero.name}</strong>. Save one in
+          your deckbuilder to auto-apply sideboard adjustments.
+        </p>
+        {(() => {
+          const matchupsHref = buildMatchupsLink(deckLink);
+          if (matchupsHref) {
+            const isBazaar = matchupsHref.startsWith(FAB_BAZAAR_DECK_PREFIX);
+            return (
+              <a
+                href={matchupsHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.noDataLearnLink}
+              >
+                {isBazaar ? 'Configure matchup ↗' : 'Open deck ↗'}
+              </a>
+            );
+          }
+          return (
+            <a
+              href={FAB_BAZAAR_LEARN_MORE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.noDataLearnLink}
+            >
+              Learn more ↗
+            </a>
+          );
+        })()}
+      </div>
+    </>
+  );
 };
 
 export default Matchups;

--- a/src/routes/game/lobby/components/matchups/Matchups.tsx
+++ b/src/routes/game/lobby/components/matchups/Matchups.tsx
@@ -12,7 +12,11 @@ import { generateCroppedImageUrl } from 'utils/cropImages';
 import styles from './Matchups.module.css';
 import MatchupTooltip from './MatchupTooltip';
 
-const FAB_BAZAAR_LEARN_MORE_URL = 'https://fabbazaar.app/tutorials/talishar';
+// A hero entry that has been resolved from a saved matchup or the legalHeroes
+// list. `id` is whichever identifier we have (slug from backend, or card-ID
+// from HEROES_OF_RATHE). `class` is empty when sourced from HEROES_OF_RATHE
+// alone; populated when sourced from / overridden by backend `legalHeroes`.
+type ResolvedHero = { id: string; name: string; class: string };
 
 export interface Matchups {
   refetch: () => void;
@@ -76,7 +80,7 @@ const Matchups = ({
   // HEROES_OF_RATHE; backend's legalHeroes is layered on top to attach the
   // class string when available.
   const HERO_BY_NAME = useMemo(() => {
-    const map = new Map<string, { id: string; name: string; class: string }>();
+    const map = new Map<string, ResolvedHero>();
     for (const h of HEROES_OF_RATHE) {
       map.set(h.label.toLowerCase(), { id: h.value, name: h.label, class: '' });
     }
@@ -89,7 +93,7 @@ const Matchups = ({
   }, [gameLobby?.legalHeroes]);
 
   const HERO_BY_ID = useMemo(() => {
-    const map = new Map<string, { id: string; name: string; class: string }>();
+    const map = new Map<string, ResolvedHero>();
     // Card-ID keyed (e.g. "DYN113")
     for (const h of HEROES_OF_RATHE) {
       map.set(h.value, { id: h.value, name: h.label, class: '' });
@@ -103,7 +107,7 @@ const Matchups = ({
 
   // Resolve a saved matchup to a hero entry if it conceptually targets one.
   // First try matchupId (slug or card ID), then the matchup's display name.
-  const resolveHero = (m: { matchupId: string; name?: string | null }) => {
+  const resolveHero = (m: { matchupId: string; name?: string | null }): ResolvedHero | null => {
     return (
       HERO_BY_ID.get(m.matchupId) ??
       (m.name ? HERO_BY_NAME.get(m.name.toLowerCase()) : undefined) ??
@@ -121,7 +125,7 @@ const Matchups = ({
   // side. When the backend hasn't sent `legalHeroes`, all hero matchups
   // are shown (no ban data available to filter on).
   const { savedHeroMatchups, customMatchups } = useMemo(() => {
-    const heroes: { hero: { id: string; name: string; class: string }; matchup: Matchup }[] = [];
+    const heroes: { hero: ResolvedHero; matchup: Matchup }[] = [];
     const customs: Matchup[] = [];
 
     const legalList = gameLobby?.legalHeroes;
@@ -211,9 +215,9 @@ const Matchups = ({
   );
 
   // Group by backend-supplied class (e.g. "RUNEBLADE" -> "Runeblade").
-  // When the backend hasn't shipped legalHeroes (fallback path), `class` is
-  // empty and everything buckets under "Other" — still functional, just less
-  // organized until the backend ships.
+  // Heroes whose `class` is empty bucket under "Other" as a safety net —
+  // shouldn't happen in normal operation since the backend computes class
+  // via CardClass() for every legal hero.
   const groupedMatchups = useMemo(() => {
     const groups: Record<string, typeof filteredUnsavedHeroes> = {};
     for (const h of filteredUnsavedHeroes) {
@@ -469,27 +473,16 @@ const NoDataPopover = ({
         </p>
         {(() => {
           const matchupsHref = buildMatchupsLink(deckLink);
-          if (matchupsHref) {
-            const isBazaar = matchupsHref.startsWith(FAB_BAZAAR_DECK_PREFIX);
-            return (
-              <a
-                href={matchupsHref}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.noDataLearnLink}
-              >
-                {isBazaar ? 'Configure matchup ↗' : 'Open deck ↗'}
-              </a>
-            );
-          }
+          if (!matchupsHref) return null;
+          const isBazaar = matchupsHref.startsWith(FAB_BAZAAR_DECK_PREFIX);
           return (
             <a
-              href={FAB_BAZAAR_LEARN_MORE_URL}
+              href={matchupsHref}
               target="_blank"
               rel="noopener noreferrer"
               className={styles.noDataLearnLink}
             >
-              Learn more ↗
+              {isBazaar ? 'Configure matchup ↗' : 'Open deck ↗'}
             </a>
           );
         })()}

--- a/src/routes/game/lobby/components/matchups/Matchups.tsx
+++ b/src/routes/game/lobby/components/matchups/Matchups.tsx
@@ -1,6 +1,5 @@
 import { useAppSelector } from 'app/Hooks';
 import { RootState } from 'app/Store';
-import { GAME_FORMAT } from 'appConstants';
 import { useJoinGameMutation } from 'features/api/apiSlice';
 import { getGameInfo } from 'features/game/GameSlice';
 import { Matchup, LegalHero } from 'interface/API/GetLobbyRefresh.php';
@@ -21,15 +20,8 @@ export interface Matchups {
   onMatchupSelected?: (matchupId: string) => void;
   isAutoApplyingMatchup?: boolean;
   onExpandChat?: () => void;
-  format?: string;
   isBazaarDeck?: boolean;
 }
-
-const BLITZ_FORMATS = new Set([
-  GAME_FORMAT.BLITZ, GAME_FORMAT.COMPETITIVE_BLITZ, GAME_FORMAT.OPEN_BLITZ,
-  GAME_FORMAT.SAGE, GAME_FORMAT.COMPETITIVE_SAGE, GAME_FORMAT.OPEN_SAGE,
-  GAME_FORMAT.COMMONER,
-]);
 
 const Matchups = ({
   refetch,
@@ -37,7 +29,6 @@ const Matchups = ({
   onMatchupSelected,
   isAutoApplyingMatchup = false,
   onExpandChat,
-  format,
   isBazaarDeck = false,
 }: Matchups) => {
   const [isUpdating, setIsUpdating] = useState(false);
@@ -159,41 +150,28 @@ const Matchups = ({
     return { savedHeroMatchups: heroes, customMatchups: customs };
   }, [gameLobby?.matchups, gameLobby?.legalHeroes, HERO_BY_ID, HERO_BY_NAME]);
 
-  // Format-legal heroes that AREN'T already saved (the discovery grid for Bazaar).
-  // Non-Bazaar decks don't show this section at all.
-  // When the backend sent `legalHeroes`, that list is already ban-filtered and
-  // format-filtered. Otherwise we fall back to HEROES_OF_RATHE + young flag.
+  // Format-legal heroes that AREN'T already saved (the discovery grid for
+  // Bazaar). Sourced exclusively from the backend's `legalHeroes` list —
+  // it has already applied the format-tier and ban filters via CardClass()
+  // and isBannedInFormat(). When the field isn't present on the response
+  // (older backend), the discovery grid simply doesn't render — better than
+  // guessing format legality on the FE.
   const unsavedHeroes = useMemo(() => {
     if (!isBazaarDeck) return [];
-    const savedHeroIds = new Set(savedHeroMatchups.map((s) => s.hero.id));
     const fromBackend = gameLobby?.legalHeroes;
-    if (fromBackend && fromBackend.length > 0) {
-      return fromBackend
-        .filter((h) => !savedHeroIds.has(h.heroId))
-        .map((h) => ({
-          matchupId: h.heroId,
-          name: h.name,
-          class: h.class,
-          preferredTurnOrder: null as string | null,
-          notes: null as string | null,
-          hasData: false,
-        }));
-    }
-    // Fallback: derive from FE constants (NO ban filter — heroes that are banned
-    // in the current format will incorrectly appear)
-    const useYoung = format ? BLITZ_FORMATS.has(format) : false;
-    return HEROES_OF_RATHE
-      .filter((h) => !!h.young === useYoung)
-      .filter((h) => !savedHeroIds.has(h.value))
+    if (!fromBackend || fromBackend.length === 0) return [];
+    const savedHeroIds = new Set(savedHeroMatchups.map((s) => s.hero.id));
+    return fromBackend
+      .filter((h) => !savedHeroIds.has(h.heroId))
       .map((h) => ({
-        matchupId: h.value,
-        name: h.label,
-        class: '',
+        matchupId: h.heroId,
+        name: h.name,
+        class: h.class,
         preferredTurnOrder: null as string | null,
         notes: null as string | null,
         hasData: false,
       }));
-  }, [format, savedHeroMatchups, isBazaarDeck, gameLobby?.legalHeroes]);
+  }, [savedHeroMatchups, isBazaarDeck, gameLobby?.legalHeroes]);
 
   const matchesSearch = (s: string) =>
     s.toLowerCase().includes(searchTerm.toLowerCase());

--- a/src/routes/game/lobby/components/stickyFooter/StickyFooter.module.css
+++ b/src/routes/game/lobby/components/stickyFooter/StickyFooter.module.css
@@ -20,9 +20,7 @@
   grid-template-columns: 3em auto 3em 1fr auto auto;
   padding: 1em 0.5em;
   gap: 0.5em;
-  grid-template-areas:
-    'clipboard start content . deckCount submit'
-    '. . . . alarm alarm';
+  grid-template-areas: 'clipboard start content . deckCount submit';
   align-items: center;
 }
 
@@ -34,21 +32,55 @@
   grid-area: deckCount;
 }
 
-.footerAlarm {
-  grid-area: alarm;
+.deckCount {
   display: flex;
-  justify-content: flex-end;
-  gap: 0.5em;
-  width: 100%;
-  min-height: 0;
+  align-items: center;
+  gap: 0.4rem;
+  white-space: nowrap;
 }
 
-.footerAlarm > * {
-  padding: 0.5em 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  display: flex;
-  justify-content: center;
-  width: auto;
+@keyframes pulseWarning {
+  0%, 100% { opacity: 0.45; }
+  50% { opacity: 1; }
+}
+
+.deckErrorIcon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  color: #E67E22;
+  font-size: 1.1em;
+  animation: pulseWarning 1.6s ease-in-out infinite;
+  cursor: default;
+  flex-shrink: 0;
+}
+
+.deckErrorIcon:hover {
+  animation: none;
+  opacity: 1;
+}
+
+.deckErrorTooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(20, 24, 28, 0.97);
+  border: 1px solid rgba(230, 126, 34, 0.55);
+  color: #E67E22;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.3rem 0.65rem;
+  border-radius: 5px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  z-index: 100;
+}
+
+.deckErrorIcon:hover .deckErrorTooltip {
+  opacity: 1;
 }
 
 .buttonHolder {
@@ -77,21 +109,6 @@
   transition: 0.7s;
 }
 
-.alarm {
-  /* Use orange-amber instead of red so the text is visible for users with
-     red color blindness (protanopia / deuteranopia). Combine with bold weight
-     and a subtle border so the error is not conveyed by color alone. */
-  color: #E67E22;
-  font-weight: 600;
-  border: 1px solid rgba(230, 126, 34, 0.45);
-  border-radius: 4px;
-  padding: 0.2rem 0.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  font-size: 0.95rem;
-}
 
 .clipboardButtonHolder {
   grid-area: clipboard;
@@ -220,11 +237,6 @@
     width: auto;
   }
 
-  .footerAlarm {
-    width: 100%;
-    order: 10;
-  }
-
   .syncInlineText {
     max-width: 150px;
   }
@@ -288,12 +300,6 @@
 
   .stickyFooter {
     border-top: 1px solid rgba(255, 255, 255, 0.15);
-  }
-
-  .footerAlarm {
-    width: 100%;
-    order: 10;
-    min-height: 0;
   }
 
   .syncInline {

--- a/src/routes/game/lobby/components/stickyFooter/StickyFooter.tsx
+++ b/src/routes/game/lobby/components/stickyFooter/StickyFooter.tsx
@@ -61,15 +61,18 @@ const StickyFooter = ({
       }
     };
 
-    // Initial update
     updateFooterHeight();
-
-    // Small delay to ensure DOM is fully rendered on mobile
     const timer = setTimeout(updateFooterHeight, 100);
+
+    const observer = footerRef.current
+      ? new ResizeObserver(updateFooterHeight)
+      : null;
+    if (observer && footerRef.current) observer.observe(footerRef.current);
 
     window.addEventListener('resize', updateFooterHeight);
     return () => {
       clearTimeout(timer);
+      observer?.disconnect();
       window.removeEventListener('resize', updateFooterHeight);
     };
   }, []);
@@ -163,15 +166,14 @@ const StickyFooter = ({
             </div>
           )}
         </div>
-        <div className={styles.footerAlarm}>
-          {!isValid && (
-            <div className={styles.alarm}>
-              <FaExclamationCircle /> {errorArray[0]}
-            </div>
-          )}
-        </div>
         <div className={styles.footerContent}>
-          <div>
+          <div className={styles.deckCount}>
+            {!isValid && errorArray.length > 0 && (
+              <span className={styles.deckErrorIcon}>
+                <FaExclamationCircle />
+                <span className={styles.deckErrorTooltip}>{errorArray[0]}</span>
+              </span>
+            )}
             Deck {values.deck.length}/{deckSize}
           </div>
         </div>


### PR DESCRIPTION
## Summary

Visual redesign of the lobby (full-height grid, refined chat column, inline deck-error icon) plus a partitioned matchups panel that distinguishes hero-backed matchups (rendered as portrait tiles) from custom-named matchups (rendered as full-width buttons).

The matchups panel:
- Promotes saved hero matchups (color portraits) and saved custom-named matchups (rounded buttons) to a "SAVED PROFILES" section at the top
- For Bazaar decks, shows a discovery grid below of unsaved heroes grouped by class (Assassin/Brute/Guardian/etc.)
- Pins the matchup against the opponent's current hero to the upper-left when known
- Hides hero matchups for heroes banned in the current format (defends against deckbuilders that don't validate format bans)
- Opens a small anchored popover when an unsaved hero is clicked, deep-linking to the deck's matchups configuration page on the source deckbuilder (e.g. `fabbazaar.app/decks/{id}/matchups`)

## Backend dependency

This PR consumes a new `legalHeroes` field on the `GetLobbyInfo` / `GetLobbyRefresh` response. Backend-side change is in **Talishar/Talishar#1386**. The two should land together; see "Behavior without the backend field" below for graceful-degradation notes.

The field gives the FE a format-aware, ban-filtered, class-tagged hero list computed once server-side via the existing `isBannedInFormat()` and `CardClass()` helpers — eliminating the need to maintain a duplicate hero universe / class map / format-tier split on the FE.

## Other lobby polish bundled in

- **Compact left chat column** (mini chat log + quick-chat chips + gold "Open Chat ▸" button) when matchups panel is visible; expands to full `<LobbyChat />` on toggle. Toggle is a panel-internal button — the nav bar is **structurally identical to upstream**.
- **`StickyFooter` inline deck-error icon** (pulsing amber, hover tooltip) replaces the previous growing footer banner.
- **Phantom black band above footer eliminated** by neutralizing pico's default `<form>` margin and the `matchupContainer` `<article>` margin (both are CSS Grid items, their margins were sizing the row).
- **`LobbyChat` container height fixed** (replaces hardcoded `calc(100dvh - 440px)` with `flex: 1`) so chat fills the available column space.
- **`Equipment` container** now uses `flex: 1 + min-height: 0` so its overflow scrolls cleanly when chat-expanded narrows the deck column.
- **`StickyFooter` `ResizeObserver`** keeps `--sticky-footer-height` in sync as footer content changes (sync chip, error icon).

## Behavior without the backend field

The FE consumes `gameLobby.legalHeroes` when present. When absent (older backend version):
- The Bazaar discovery grid simply doesn't render (better than guessing format legality on the FE).
- Saved profiles still display correctly — `HEROES_OF_RATHE` is used only as a hero universe for recognizing matchups as hero-backed, never for legality decisions.

So merging this FE PR before the BE PR is safe: users see a slightly degraded matchups experience (no discovery grid for Bazaar decks) until the backend lands, then everything fills in automatically.

## Scope & blast radius

- **9 files modified, 0 added, 0 deleted, 4 commits, +1,122 / −364 net lines.**
- Every modified file is under `src/routes/game/lobby/`. All CSS is in `*.module.css` files (build-time hashed, can't leak to other components).
- Every modified component (`Lobby`, `Matchups`, `LobbyChat`, `Equipment`, `StickyFooter`) is consumed only by `Lobby.tsx` — verified via codebase-wide grep. **No blast radius outside the lobby.**
- The nav bar is structurally identical to upstream — no nav buttons added, removed, or reordered.
- `package.json` / `package-lock.json` unchanged (no new runtime dependencies).

## Commit history

The branch is structured as one feature commit + three progressive cleanup commits, each readable on its own:

```
980ffd2ff Tighten Matchups.tsx + restore .heroName upstream behavior
dd5a6fd09 Drop FE BLITZ_FORMATS — rely on backend for hero universe
0b76fdaed Drop FE HERO_CLASS_MAP — rely on backend's class field
7f15a6108 Lobby redesign + matchups panel with legalHeroes consumer
```

The cleanup commits show the migration from FE-side fallbacks to backend source-of-truth (PR #1386).

## Test plan

- [x] `npx tsc --noEmit` clean (no new type errors)
- [x] Lobby loads correctly with both Bazaar and non-Bazaar (Fabrary, FabDB) deck URLs
- [x] Saved hero matchups render as portraits in SAVED PROFILES; custom-named matchups render as buttons
- [x] Banned heroes (e.g. Verdance against a CC deck) are dropped from rendering when backend `legalHeroes` is present
- [x] Discovery grid (Bazaar only) shows unsaved heroes grouped by class
- [x] Click on unsaved hero opens anchored popover with "Configure matchup ↗" link to `fabbazaar.app/decks/{id}/matchups`
- [x] Compact ↔ expanded chat toggle works in both directions
- [x] Sticky footer error icon pulses when deck is invalid; hover shows tooltip
- [x] No phantom band between content and footer at multiple viewport sizes
- [ ] Reviewer to confirm: any concerns about the size of the diff for a single PR? Happy to split into "lobby polish" + "matchups feature" if preferred.