### PR TITLE
Fix Fabrary matchup resolution + lobby redesign

### DIFF
--- a/src/interface/API/GetLobbyRefresh.php.ts
+++ b/src/interface/API/GetLobbyRefresh.php.ts
@@ -38,10 +38,9 @@ export interface GetLobbyRefreshResponse {
 export interface Matchup {
   matchupId: string;
   name: string;
-  heroIdenfitiers?: string[]; // Fabrary's typo is canonical; hero slugs e.g. ["bravo-showstopper"]
+  heroIdentifiers?: string[]; // hero slugs e.g. ["bravo-showstopper"]
   preferredTurnOrder?: string | null; // "1st", "2nd", or null
   notes?: string | null; // HTML notes from Fabrary
-  heroIdentifiers?: string[]; // Canonical hero card IDs from FaBrary API (e.g. ["briar", "briar-warden-of-thorns"])
 }
 
 // Heroes the backend has determined are legal for the current deck's format.

--- a/src/interface/API/GetLobbyRefresh.php.ts
+++ b/src/interface/API/GetLobbyRefresh.php.ts
@@ -28,6 +28,7 @@ export interface GetLobbyRefreshResponse {
   canUnreadySideboard?: boolean;
   myDeckLink?: string;
   matchups?: Matchup[];
+  legalHeroes?: LegalHero[];
   chatEnabled?: boolean;
   chatInvited?: boolean;
   opponentIsTyping?: boolean;
@@ -37,7 +38,22 @@ export interface GetLobbyRefreshResponse {
 export interface Matchup {
   matchupId: string;
   name: string;
+  heroIdenfitiers?: string[]; // Fabrary's typo is canonical; hero slugs e.g. ["bravo-showstopper"]
   preferredTurnOrder?: string | null; // "1st", "2nd", or null
   notes?: string | null; // HTML notes from Fabrary
   heroIdentifiers?: string[]; // Canonical hero card IDs from FaBrary API (e.g. ["briar", "briar-warden-of-thorns"])
+}
+
+// Heroes the backend has determined are legal for the current deck's format.
+// Already filtered: bans applied (via JoinGame.php isBannedInFormat),
+// young/adult split applied for the format. The FE renders these directly
+// as the discovery grid for Bazaar decks; no further filtering needed.
+//
+// If absent (older backend versions), the FE falls back to its local
+// HEROES_OF_RATHE constant + young flag — without ban filtering.
+export interface LegalHero {
+  heroId: string;   // slug, e.g. "briar_warden_of_thorns"
+  name: string;     // display name, e.g. "Briar Warden of Thorns"
+  class: string;    // class name from CardClass(): "RUNEBLADE", "WIZARD", "ASSASSIN", etc.
+  young?: boolean;  // optional; backend has already format-filtered, FE doesn't re-filter
 }

--- a/src/routes/game/lobby/Lobby.module.css
+++ b/src/routes/game/lobby/Lobby.module.css
@@ -514,24 +514,27 @@ h3 {
 }
 
 .quickChatStrip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.28rem;
-  padding: 0.15rem 0.05rem;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.2rem;
+  padding: 0.1rem 0;
   flex-shrink: 0;
 }
 
 .quickChatChip {
-  font-size: 0.65rem;
+  font-size: 0.6rem;
   font-weight: 600;
-  padding: 0.22rem 0.55rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  padding: 0.18rem 0.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.03);
-  color: rgba(255, 255, 255, 0.65);
-  border-radius: 999px;
+  color: rgba(255, 255, 255, 0.5);
+  border-radius: 4px;
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: center;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
   width: auto;
   margin: 0;
 }
@@ -539,16 +542,53 @@ h3 {
 .quickChatChip:hover {
   background: rgba(217, 184, 74, 0.1);
   color: #f0d070;
-  border-color: rgba(217, 184, 74, 0.4);
-  transform: translateY(-1px);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  border-color: rgba(217, 184, 74, 0.35);
 }
 
 .quickChatChip:active {
   background: rgba(217, 184, 74, 0.18);
   color: #fff;
-  transform: translateY(0);
+}
+
+.quickChatChip:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+}
+
+.chatBottomBar {
+  display: flex;
+  gap: 0.35rem;
+  flex-shrink: 0;
+  margin-top: 0.25rem;
+}
+
+.chatBottomBtn {
+  flex: 1;
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.6);
+  border-radius: 5px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  margin: 0;
+  width: auto;
+}
+
+.chatBottomBtn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.9);
+  border-color: rgba(255, 255, 255, 0.25);
+  transform: none;
   box-shadow: none;
+}
+
+.chatBottomBtn.active {
+  background: rgba(217, 184, 74, 0.12);
+  color: #d9b84a;
+  border-color: rgba(217, 184, 74, 0.45);
 }
 
 .chatExpandBtn {

--- a/src/routes/game/lobby/Lobby.module.css
+++ b/src/routes/game/lobby/Lobby.module.css
@@ -10,10 +10,7 @@ h3 {
 }
 
 .titleContainer {
-  position: -webkit-sticky; /* Safari */
-  position: sticky;
-  top: -208px;
-  height: 240px;
+  height: 120px;
   width: 100%;
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -75,12 +72,20 @@ h3 {
 @media (min-width: 1200px) {
   .chatAreaContainerRestrained {
     grid-area: chat;
+    grid-row: 1 / span 2;
     min-height: 0;
+    height: 100%;
+    align-self: stretch;
+    padding: 0.75rem 0.5rem 0;
   }
 
   .chatAreaContainer {
     grid-area: chat;
+    grid-row: 1 / span 2;
     min-height: 0;
+    height: 100%;
+    align-self: stretch;
+    padding: 0.75rem 0.5rem 0;
   }
 }
 
@@ -92,7 +97,7 @@ h3 {
 
 .leftCol {
   background-size: cover;
-  background-position: center;
+  background-position: center 15%;
   height: 100%;
   border: none;
   overflow: hidden;
@@ -126,7 +131,7 @@ h3 {
 .rightCol {
   text-align: right;
   background-size: cover;
-  background-position: center;
+  background-position: center 15%;
   height: 100%;
   border: none;
   overflow: hidden;
@@ -162,12 +167,12 @@ h3 {
   flex-direction: column;
   justify-content: flex-end;
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  padding: 1.2em;
-  padding-bottom: 0.8em;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  padding: 0.4em;
+  padding-bottom: 0.3em;
   color: var(--white);
   text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.9), 0 0 4px rgba(0, 0, 0, 0.8);
   background: linear-gradient(
@@ -181,13 +186,16 @@ h3 {
 }
 
 .dimPic > h3 {
-  margin-bottom: 0.3em;
-  font-size: 1.3em;
+  margin-bottom: 0.1em;
+  font-size: 0.8em;
   font-weight: 700;
   text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.9), 0 0 4px rgba(0, 0, 0, 0.8);
   color: white;
   transition: all 0.3s ease;
   letter-spacing: 0.5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .leftCol:hover .dimPic > h3,
@@ -280,7 +288,7 @@ h3 {
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.5rem;
+  padding: 0.2rem 0.5rem;
 }
 
 .inLineNav ul {
@@ -412,11 +420,184 @@ h3 {
 @media (min-width: 1200px) {
   .deckSelectorContainer {
     grid-area: weapons;
-    grid-row: 1 / span 2;
     display: flex;
     flex-direction: column;
     overflow-y: hidden;
+    height: 100%;
+    align-self: stretch;
+    min-height: 0;
   }
+}
+
+.compactChat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0 0.1rem 0.25rem;
+  height: 100%;
+  overflow: hidden;
+}
+
+.compactChatHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+  padding: 0.35rem 0.2rem 0.4rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: 0.15rem;
+  flex-shrink: 0;
+}
+
+.compactChatHeader::before {
+  content: '';
+  display: inline-block;
+  width: 4px;
+  height: 12px;
+  background: linear-gradient(180deg, #d9b84a 0%, rgba(217, 184, 74, 0.4) 100%);
+  border-radius: 2px;
+}
+
+.compactChatLog {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  font-size: 0.7rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.82);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.025) 0%,
+    rgba(0, 0, 0, 0.18) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 0.5rem 0.55rem;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
+}
+
+.compactChatLog::-webkit-scrollbar {
+  width: 6px;
+}
+
+.compactChatLog::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.compactChatLog::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 3px;
+}
+
+.compactChatLog > div {
+  padding: 0.18rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.compactChatLog > div:last-child {
+  border-bottom: none;
+}
+
+.compactChatEmpty {
+  display: block;
+  color: rgba(255, 255, 255, 0.32);
+  font-style: italic;
+  font-size: 0.68rem;
+  text-align: center;
+  padding: 1.5rem 0;
+  border-bottom: none !important;
+}
+
+.quickChatStrip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.28rem;
+  padding: 0.15rem 0.05rem;
+  flex-shrink: 0;
+}
+
+.quickChatChip {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.22rem 0.55rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.03);
+  color: rgba(255, 255, 255, 0.65);
+  border-radius: 999px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+  width: auto;
+  margin: 0;
+}
+
+.quickChatChip:hover {
+  background: rgba(217, 184, 74, 0.1);
+  color: #f0d070;
+  border-color: rgba(217, 184, 74, 0.4);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.quickChatChip:active {
+  background: rgba(217, 184, 74, 0.18);
+  color: #fff;
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.chatExpandBtn {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid rgba(209, 170, 60, 0.55);
+  background: rgba(209, 170, 60, 0.12);
+  color: #d9b84a;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  width: 100%;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.chatExpandBtn:hover {
+  background: rgba(209, 170, 60, 0.22);
+  color: #f0d070;
+  border-color: rgba(209, 170, 60, 0.8);
+  transform: none;
+  box-shadow: none;
+}
+
+.chatToggleBtn {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  border: 1px solid rgba(209, 170, 60, 0.55);
+  background: rgba(209, 170, 60, 0.12);
+  color: #d9b84a;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  flex-shrink: 0;
+  margin: 0.25rem 0 0.5rem;
+}
+
+.chatToggleBtn:hover {
+  background: rgba(209, 170, 60, 0.22);
+  color: #f0d070;
+  border-color: rgba(209, 170, 60, 0.8);
+  transform: none;
+  box-shadow: none;
 }
 
 nav {
@@ -458,10 +639,12 @@ nav {
   background: transparent;
   border-radius: 0;
   border: none;
-  padding: 1rem;
+  padding: 0.4rem 0.5rem;
   box-shadow:
     0 20px 44px rgba(0, 0, 0, 0.32),
     0 2px 10px rgba(0, 0, 0, 0.22);
+  font-size: 0.78rem;
+  overflow-y: auto;
 }
 
 .matchupsContainer {
@@ -473,6 +656,10 @@ nav {
   box-shadow:
     0 20px 44px rgba(0, 0, 0, 0.32),
     0 2px 10px rgba(0, 0, 0, 0.22);
+}
+
+.form {
+  margin: 0;
 }
 
 .gridLayout {
@@ -571,38 +758,53 @@ nav {
   .lobbyClass {
     position: fixed;
     top: 0px;
-    bottom: 110px;
+    bottom: var(--sticky-footer-height, 80px);
     overflow-y: hidden;
   }
 
   .form {
-    min-height: 100%;
+    height: 100%;
+    width: 100%;
+    margin: 0;
     overflow-y: hidden;
     display: flex;
+    flex-direction: column;
   }
 
   .gridLayout {
-    gap: 0.5em;
+    column-gap: 0.5em;
+    row-gap: 0.15em;
     padding: 0.5em;
-    min-height: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
     overflow-y: hidden;
     display: grid;
-    grid-template-columns: 1fr 2fr 260px;
-    grid-template-rows: 240px 1fr;
+    grid-template-columns: 180px 1fr 360px;
+    grid-template-rows: 120px 1fr;
     grid-template-areas:
-      'hero weapons matchups'
+      'chat heroes matchups'
       'chat weapons matchups';
+    transition: grid-template-columns 0.25s ease;
   }
 
   .gridLayout.noMatchups {
-    grid-template-columns: 1fr 2fr 0px;
+    grid-template-columns: 180px 1fr 0px;
     grid-template-areas:
-      'hero weapons'
+      'chat heroes'
       'chat weapons';
   }
 
+  .gridLayout.chatExpanded {
+    grid-template-columns: 380px 1fr 0px;
+    grid-template-areas:
+      'chat heroes matchups'
+      'chat weapons matchups';
+  }
+
   .titleContainer {
-    grid-area: hero;
+    grid-area: heroes;
+    position: relative;
+    top: auto;
   }
 }
 

--- a/src/routes/game/lobby/Lobby.tsx
+++ b/src/routes/game/lobby/Lobby.tsx
@@ -77,8 +77,6 @@ const FAB_BAZAAR_LEARN_MORE_URL = 'https://fabbazaar.app/tutorials/talishar';
 // FaBrary uses hyphens (e.g. "briar-warden-of-thorns"), Talishar uses underscores.
 const normalizeHeroId = (id: string) => id.toLowerCase().replace(/-/g, '_');
 
-// Strip emoji and punctuation from a FaBrary matchup display name for fuzzy matching.
-// e.g. "🪴Briar" → "briar", "🏀 Vynnset" → "vynnset"
 const normalizeMatchupName = (name: string): string =>
   name
     .replace(/[\p{Emoji_Presentation}\p{Extended_Pictographic}\uFE0F\u200D]/gu, '')
@@ -91,7 +89,8 @@ const LOBBY_PRESETS = [
   { id: 1,  label: 'Hello' },
   { id: 2,  label: 'GLHF' },
   { id: 4,  label: 'BRB' },
-  { id: 5,  label: 'Undo?' },
+  { id: 3,  label: 'You there?' },
+  { id: 8,  label: 'Thinking...' },
   { id: 7,  label: 'No prob!' },
   { id: 20, label: 'Chat?' },
 ];
@@ -1366,18 +1365,28 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
                       </button>
                     )}
                     <>{showCalculator ? <Calculator /> : <LobbyChat />}</>
-                    <button
-                      className={classNames(styles.smallButton, {
-                        [styles.active]: showCalculator
-                      })}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        toggleShowCalculator();
-                      }}
-                      disabled={false}
-                    >
-                      Hand Draw Probabilities
-                    </button>
+                    <div className={styles.chatBottomBar}>
+                      {isWideScreen && hasMatchups && (
+                        <button
+                          type="button"
+                          className={styles.chatBottomBtn}
+                          onClick={() => setChatExpanded(false)}
+                        >
+                          ◂ Matchups
+                        </button>
+                      )}
+                      <button
+                        className={classNames(styles.chatBottomBtn, {
+                          [styles.active]: showCalculator
+                        })}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          toggleShowCalculator();
+                        }}
+                      >
+                        Hand Probabilities
+                      </button>
+                    </div>
                   </>
                 )}
               </div>

--- a/src/routes/game/lobby/Lobby.tsx
+++ b/src/routes/game/lobby/Lobby.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { usePageTitle } from 'hooks/usePageTitle';
+import { parseHtmlToReactElements } from 'utils/ParseEscapedString';
 import Deck from './components/deck/Deck';
 import LobbyChat from './components/lobbyChat/LobbyChat';
+import { CHAT_WHEEL } from 'constants/chatMessages';
+import { useSendGameChat } from 'hooks/useSendGameChat';
 import Calculator from './components/calculator/Calculator';
 import testData from './mockdata.json';
 import styles from './Lobby.module.css';
@@ -84,6 +87,15 @@ const normalizeMatchupName = (name: string): string =>
     .toLowerCase()
     .replace(/\s+/g, '_');
 
+const LOBBY_PRESETS = [
+  { id: 1,  label: 'Hello' },
+  { id: 2,  label: 'GLHF' },
+  { id: 4,  label: 'BRB' },
+  { id: 5,  label: 'Undo?' },
+  { id: 7,  label: 'No prob!' },
+  { id: 20, label: 'Chat?' },
+];
+
 const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
   if (!deckLink) return null;
   // Strip the "{index}<fav>" prefix that appears when a favorite deck link is stored
@@ -120,7 +132,9 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
   );
   const [isAutoApplyingMatchup, setIsAutoApplyingMatchup] =
     useState<boolean>(false);
+  const [chatExpanded, setChatExpanded] = useState(false);
   const lastAutoAppliedMatchupKey = useRef<string>('');
+  const { sendQuickChat } = useSendGameChat();
   const submittedMatchupRef = useRef<string | null>(null);
   const deckLinkTrackingRef = useRef<{ link: string | undefined; gameKey: string }>({
     link: undefined,
@@ -1024,7 +1038,8 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
           <FormikDebugLogger />
           <div
             className={classNames(styles.gridLayout, {
-              [styles.noMatchups]: !hasMatchups
+              [styles.noMatchups]: !hasMatchups,
+              [styles.chatExpanded]: chatExpanded && isWideScreen && hasMatchups,
             })}
           >
             <div className={styles.titleContainer}>
@@ -1248,7 +1263,7 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
                       </button>
                     </li>
                   </ul>
-                  <div style={{ marginLeft: 'auto' }}>
+                  <div style={{ marginLeft: '1rem' }}>
                     <DesktopDeckSelectionButtons
                       deckIndexed={deckIndexed}
                       deckSBIndexed={deckSBIndexed}
@@ -1315,19 +1330,56 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
                     : styles.chatAreaContainer
                 }
               >
-                <>{showCalculator ? <Calculator /> : <LobbyChat />}</>
-                <button
-                  className={classNames(styles.smallButton, {
-                    [styles.active]: showCalculator
-                  })}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    toggleShowCalculator();
-                  }}
-                  disabled={false}
-                >
-                  Hand Draw Probabilities
-                </button>
+                {isWideScreen && !chatExpanded && hasMatchups ? (
+                  <div className={styles.compactChat}>
+                    <div className={styles.compactChatHeader}>Chat</div>
+                    <MiniChatLog />
+                    <div className={styles.quickChatStrip}>
+                      {LOBBY_PRESETS.map(({ id, label }) => (
+                        <button
+                          key={id}
+                          type="button"
+                          className={styles.quickChatChip}
+                          onClick={() => sendQuickChat(CHAT_WHEEL.get(id) ?? '')}
+                        >
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                    <button
+                      type="button"
+                      className={styles.chatExpandBtn}
+                      onClick={() => setChatExpanded(true)}
+                    >
+                      Open Chat ▸
+                    </button>
+                  </div>
+                ) : (
+                  <>
+                    {isWideScreen && hasMatchups && (
+                      <button
+                        type="button"
+                        className={styles.chatToggleBtn}
+                        onClick={() => setChatExpanded(false)}
+                      >
+                        ◂ Matchups
+                      </button>
+                    )}
+                    <>{showCalculator ? <Calculator /> : <LobbyChat />}</>
+                    <button
+                      className={classNames(styles.smallButton, {
+                        [styles.active]: showCalculator
+                      })}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        toggleShowCalculator();
+                      }}
+                      disabled={false}
+                    >
+                      Hand Draw Probabilities
+                    </button>
+                  </>
+                )}
               </div>
             )}
 
@@ -1337,13 +1389,15 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
 
             <div className={styles.spacer}></div>
 
-            {shouldShowMatchupsUI && (activeTab === 'matchups' || isWideScreen) && (
+            {shouldShowMatchupsUI && (activeTab === 'matchups' || (isWideScreen && !chatExpanded)) && (
               <Matchups
                 refetch={refetch}
                 selectedMatchupId={selectedMatchupId}
                 onMatchupSelected={setSelectedMatchupId}
                 isAutoApplyingMatchup={isAutoApplyingMatchup}
                 isReadied={!!(gameLobby?.canUnreadySideboard || gameLobby?.amIChoosingFirstPlayer)}
+                onExpandChat={isWideScreen ? () => setChatExpanded(true) : undefined}
+                isBazaarDeck={isBazaarDeckInLobby}
               />
             )}
             <StickyFooter
@@ -1393,6 +1447,31 @@ const extractBazaarDeckIdFromLink = (deckLink?: string): string | null => {
   );
 };
 
+const COMPACT_CHAT_RE = /<span[^>]*>(.*?):\s<\/span>/;
+
+const MiniChatLog = () => {
+  const chatLog = useAppSelector((state: RootState) => state.game.chatLog);
+  const chatMessages = (chatLog ?? []).filter((m) => COMPACT_CHAT_RE.test(m));
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [chatMessages.length]);
+
+  return (
+    <div className={styles.compactChatLog}>
+      {chatMessages.length === 0 ? (
+        <span className={styles.compactChatEmpty}>No messages yet</span>
+      ) : (
+        chatMessages.map((msg, i) => (
+          <div key={i}>{parseHtmlToReactElements(msg)}</div>
+        ))
+      )}
+      <div ref={bottomRef} />
+    </div>
+  );
+};
+
 const FormikDebugLogger = () => {
   const { submitCount, isValid, errors, values, isSubmitting } =
     useFormikContext<DeckResponse>();
@@ -1426,7 +1505,7 @@ const DesktopDeckSelectionButtons = ({
   deckSBIndexed,
   activeTab,
   filtersExpanded,
-  setFiltersExpanded
+  setFiltersExpanded,
 }: {
   deckIndexed: string[];
   deckSBIndexed: string[];

--- a/src/routes/game/lobby/components/equipment/Equipment.module.css
+++ b/src/routes/game/lobby/components/equipment/Equipment.module.css
@@ -8,6 +8,8 @@
   gap: 0.5em 3em;
   padding: 0 1em;
   min-width: 0px;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 

--- a/src/routes/game/lobby/components/lobbyChat/LobbyChat.module.css
+++ b/src/routes/game/lobby/components/lobbyChat/LobbyChat.module.css
@@ -3,11 +3,11 @@
   flex-direction: column;
   align-content: center;
   justify-content: flex-end;
-  align-items: flex-end;
+  align-items: stretch;
   max-width: 100%;
   min-width: 0px;
-  grid-area: chat;
-  height: calc(100dvh - 440px);
+  flex: 1;
+  min-height: 0;
 }
 
 .spacer {
@@ -18,6 +18,7 @@
   .container {
     height: calc(100dvh - 380px);
     min-height: 200px;
+    flex: 0 0 auto;
   }
 
   .spacer {

--- a/src/routes/game/lobby/components/matchups/Matchups.module.css
+++ b/src/routes/game/lobby/components/matchups/Matchups.module.css
@@ -1,72 +1,239 @@
 .matchupContainer {
-  margin: 0 auto;
-  height: auto;
   display: flex;
-  width: 100%;
-  max-width: 260px;
-  align-items: center;
-  justify-content: flex-start;
   flex-direction: column;
-  overflow-y: auto;
+  width: 100%;
+  max-width: 360px;
   grid-area: matchups;
   overflow-x: hidden;
   background: transparent;
-  padding: 0.75rem 0.5rem;
-  gap: 0.25rem;
+  margin: 0;
+  padding: 0.75rem 0.6rem;
+  gap: 0.4rem;
   position: relative;
   z-index: 1001;
-  max-height: calc(100vh - 120px);
+  min-height: 0;
+  height: 100%;
   overflow-y: auto;
 }
 
+.matchupHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+}
+
 .matchupContainer h4 {
-  margin: 0 0 0.5rem 0;
-  font-size: 1.1rem;
+  margin: 0;
+  font-size: 1rem;
   font-weight: 600;
   letter-spacing: 0.05em;
 }
 
-.emptyMatchupContainer {
-  margin: 0 auto;
-  height: auto;
-  display: flex;
-  width: 100px;
-  align-items: center;
-  justify-content: flex-start;
-  flex-direction: column;
-  overflow-y: auto;
-  grid-area: matchups;
-  overflow-x: hidden;
-  opacity: 0;
+.chatToggleBtn {
+  padding: 0.2rem 0.5rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.6);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  width: auto;
+  margin: 0;
 }
 
-.matchups {
+.chatToggleBtn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.9);
+  border-color: rgba(255, 255, 255, 0.3);
+  transform: none;
+  box-shadow: none;
+}
+
+.searchInput {
   width: 100%;
-  position: relative;
+  margin-bottom: 0.25rem;
 }
 
-.matchupButton {
+.groupsWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.classGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.groupHeader {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.65);
+  margin: 0;
+  padding-left: 0.1rem;
+}
+
+.portraitGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.35rem;
+}
+
+.namedMatchupList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.namedMatchupItem {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.88);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.matchupButtonSelected {
-  background-color: var(--theme-secondary, #606569) !important;
-  border-color: var(--theme-secondary-hover, #757a7f) !important;
-  color: var(--theme-secondary-inverse, #ffffff) !important;
-  box-shadow: 0 0 0 2px var(--theme-primary, #d4af37) inset;
+.namedMatchupItem:hover {
+  background: rgba(217, 184, 74, 0.1);
+  border-color: rgba(217, 184, 74, 0.45);
+  color: #f0d070;
 }
 
-.selectedBadge {
+.namedMatchupItem:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.namedMatchupSelected {
+  background: rgba(217, 184, 74, 0.15);
+  border-color: rgba(217, 184, 74, 0.75);
+  color: #f0d070;
+}
+
+.namedMatchupName {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.namedMatchupBadge {
+  flex-shrink: 0;
+  padding: 0.12rem 0.45rem;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: rgba(217, 184, 74, 0.95);
+  background: rgba(217, 184, 74, 0.15);
+  border: 1px solid rgba(217, 184, 74, 0.4);
+  border-radius: 999px;
+}
+
+.portraitCard {
+  position: relative;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 2px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  aspect-ratio: 3 / 4;
+  transition: border-color 0.15s ease, transform 0.1s ease;
+  width: 100%;
+}
+
+.portraitCard:hover {
+  border-color: rgba(255, 255, 255, 0.4);
+  transform: translateY(-1px);
+}
+
+.portraitCard:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.portraitCardSelected {
+  border-color: #4a9eff !important;
+  box-shadow: 0 0 0 1px #4a9eff;
+}
+
+.portraitImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center top;
+  display: block;
+  filter: grayscale(100%);
+  transition: filter 0.15s ease;
+}
+
+.portraitImgHasData {
+  filter: grayscale(0%);
+}
+
+.portraitCard:hover .portraitImg {
+  filter: grayscale(60%);
+}
+
+.portraitCard:hover .portraitImgHasData {
+  filter: grayscale(0%);
+}
+
+.portraitCardSelected .portraitImg {
+  filter: grayscale(0%);
+}
+
+.portraitOverlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0.6rem 0.4rem 0.3rem;
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.85));
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.portraitName {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+
+.turnOrderBadge {
   font-size: 0.6rem;
   font-weight: 700;
   letter-spacing: 0.06em;
-  border-radius: 0.35rem;
-  padding: 0.16rem 0.34rem;
-  background: rgba(0, 0, 0, 0.35);
-  color: #fff;
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  background: rgba(212, 175, 55, 0.2);
+  color: var(--theme-primary, #d4af37);
+  border: 1px solid rgba(212, 175, 55, 0.4);
+  width: fit-content;
 }
 
 .autoApplyingStatus {
@@ -77,117 +244,17 @@
   opacity: 0.9;
 }
 
-.matchups button {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  width: 100%;
-  padding: 0.5rem 0.75rem;
-  background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 6px;
-  color: rgba(255, 255, 255, 0.85);
-  font-weight: 400;
-  font-size: 0.875rem;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  position: relative;
-  overflow: visible;
-  margin-bottom: 0;
-}
-
-.matchups button:hover {
-  background: rgba(255, 255, 255, 0.05);
-  border-color: var(--theme-primary, #d4af37);
-  color: #fff;
-  transform: none;
-}
-
-.matchups button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  transform: none;
-}
-
-.matchups button:active {
-  background: rgba(255, 255, 255, 0.08);
-  transform: none;
-}
-
-.matchupName {
-  text-align: left;
-  font-weight: 400;
-  color: inherit;
-  flex: 1;
-  min-width: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.turnOrderBadge {
-  font-size: 0.6rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  padding: 0.15rem 0.35rem;
-  border-radius: 3px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  background: rgba(212, 175, 55, 0.15);
-  color: var(--theme-primary, #d4af37);
-  border: 1px solid rgba(212, 175, 55, 0.3);
-  box-shadow: none;
-  min-width: 2.2rem;
-  width: 2.2rem;
-  margin-left: auto;
-}
-
-/* Tablet: 3 columns, uniform sizing */
-@media (max-width: 1200px) and (min-width: 769px) {
+/* Tablet and below: horizontal scrolling strip */
+@media (max-width: 1200px) {
   .matchupContainer {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
     max-width: 100%;
-    padding: 0.75rem 0.5rem;
-    gap: 0.5rem;
-    height: auto;
+    padding: 0.5rem;
+    flex-direction: column;
     max-height: calc(100vh - var(--sticky-footer-height, 80px) - 130px - 120px);
-    overflow-y: auto;
   }
 
-  .matchupContainer h4 {
-    display: none;
-  }
-
-  .matchups {
-    width: 100%;
-  }
-
-  .matchups button {
-    padding: 0.45rem 0.5rem;
-    font-size: 0.75rem;
-    margin-bottom: 0;
-    flex-direction: row;
-    gap: 0.4rem;
-    height: auto;
-    min-height: unset;
-  }
-
-  .matchupName {
-    text-align: left;
-    width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: 0.85em;
-  }
-
-  .turnOrderBadge {
-    min-width: unset;
-    flex-shrink: 0;
+  .portraitGrid {
+    grid-template-columns: repeat(4, 1fr);
   }
 
   .autoApplyingStatus {
@@ -195,57 +262,9 @@
   }
 }
 
-/* Mobile: 2-column grid, uniform sizing */
 @media (max-width: 768px) {
-  .matchupContainer {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    max-width: 100%;
-    width: 100%;
-    padding: 0.75rem 0.5rem;
-    gap: 0.4rem;
-    height: auto;
-    max-height: calc(100vh - var(--sticky-footer-height, 80px) - 130px - 120px);
-    overflow-y: auto;
-  }
-
-  .matchupContainer h4 {
-    display: none;
-  }
-
-  .matchupContainer input[type='text'] {
-    grid-column: 1 / -1;
-    margin-bottom: 0.25rem;
-  }
-
-  .matchups {
-    width: 100%;
-  }
-
-  .matchups button {
-    padding: 0.45rem 0.5rem;
-    font-size: 0.8rem;
-    margin-bottom: 0;
-    flex-direction: row;
-    gap: 0.4rem;
-    height: auto;
-    min-height: unset;
-  }
-
-  .matchupName {
-    text-align: left;
-    width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: 0.85em;
-  }
-
-  .turnOrderBadge {
-    font-size: 0.6rem;
-    padding: 0.1rem 0.25rem;
-    min-width: unset;
-    flex-shrink: 0;
+  .portraitGrid {
+    grid-template-columns: repeat(3, 1fr);
   }
 
   .autoApplyingStatus {
@@ -253,40 +272,110 @@
   }
 }
 
-/* Small mobile: 2 columns with fixed height */
-@media (max-width: 480px) {
-  .matchupContainer {
-    grid-template-columns: repeat(2, 1fr);
-    padding: 0.5rem 0.4rem;
-    gap: 0.3rem;
-  }
+.noDataBackdrop {
+  position: fixed;
+  inset: 0;
+  background: transparent;
+  z-index: 9999;
+}
 
-  .matchupContainer h4 {
-    display: none;
-  }
+.noDataPopover {
+  position: fixed;
+  width: 260px;
+  background: linear-gradient(180deg, #242b34 0%, #1a1f25 100%);
+  border: 1px solid rgba(217, 184, 74, 0.4);
+  border-radius: 10px;
+  padding: 0.7rem 0.85rem 0.75rem;
+  box-shadow:
+    0 12px 36px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset;
+  z-index: 10000;
+  animation: noDataPopIn 0.14s cubic-bezier(0.2, 0.8, 0.3, 1.1);
+}
 
-  .matchupContainer input[type='text'] {
-    grid-column: 1 / -1;
-    margin-bottom: 0.25rem;
-  }
+@keyframes noDataPopIn {
+  from { opacity: 0; transform: translateY(-50%) scale(0.94); }
+  to   { opacity: 1; transform: translateY(-50%) scale(1); }
+}
 
-  .matchups button {
-    padding: 0.4rem 0.4rem;
-    font-size: 0.8rem;
-    gap: 0.3rem;
-    height: auto;
-    min-height: unset;
-  }
+.noDataPopover::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  background: #1f252d;
+  border: 1px solid rgba(217, 184, 74, 0.4);
+  transform: translateY(-50%) rotate(45deg);
+}
 
-  .matchupName {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: 0.85em;
-  }
+.noDataPopover[data-placement="left"]::before {
+  right: -6px;
+  border-top: none;
+  border-left: none;
+}
 
-  .turnOrderBadge {
-    font-size: 0.55rem;
-    padding: 0.1rem 0.2rem;
-  }
+.noDataPopover[data-placement="right"]::before {
+  left: -6px;
+  border-bottom: none;
+  border-right: none;
+}
+
+.noDataCloseX {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.12s ease, color 0.12s ease;
+  margin: 0;
+}
+
+.noDataCloseX:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.noDataTitle {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #f0d070;
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.02em;
+  padding-right: 1rem;
+}
+
+.noDataBody {
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.78);
+  margin: 0 0 0.5rem;
+}
+
+.noDataBody strong {
+  color: rgba(255, 255, 255, 0.95);
+  font-weight: 600;
+}
+
+.noDataLearnLink {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #d9b84a;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.noDataLearnLink:hover {
+  color: #f0d070;
+  text-decoration: underline;
 }

--- a/src/routes/game/lobby/components/matchups/Matchups.tsx
+++ b/src/routes/game/lobby/components/matchups/Matchups.tsx
@@ -2,11 +2,17 @@ import { useAppSelector } from 'app/Hooks';
 import { RootState } from 'app/Store';
 import { useJoinGameMutation } from 'features/api/apiSlice';
 import { getGameInfo } from 'features/game/GameSlice';
-import React, { useState } from 'react';
+import { Matchup, LegalHero } from 'interface/API/GetLobbyRefresh.php';
+import React, { useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { toast } from 'react-hot-toast';
 import { shallowEqual } from 'react-redux';
+import { generateCroppedImageUrl } from 'utils/cropImages';
 import styles from './Matchups.module.css';
 import MatchupTooltip from './MatchupTooltip';
+
+// A hero entry resolved from a saved matchup against the backend legalHeroes list.
+type ResolvedHero = { id: string; name: string; class: string };
 
 export interface Matchups {
   refetch: () => void;
@@ -14,6 +20,8 @@ export interface Matchups {
   onMatchupSelected?: (matchupId: string) => void;
   isAutoApplyingMatchup?: boolean;
   isReadied?: boolean;
+  onExpandChat?: () => void;
+  isBazaarDeck?: boolean;
 }
 
 const Matchups = ({
@@ -21,30 +29,24 @@ const Matchups = ({
   selectedMatchupId,
   onMatchupSelected,
   isAutoApplyingMatchup = false,
-  isReadied = false
+  isReadied = false,
+  onExpandChat,
+  isBazaarDeck = false,
 }: Matchups) => {
   const [isUpdating, setIsUpdating] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+  const [noDataHero, setNoDataHero] = useState<{
+    id: string;
+    name: string;
+    anchorRect: DOMRect;
+  } | null>(null);
 
   const gameLobby = useAppSelector(
     (state: RootState) => state.game.gameLobby,
     shallowEqual
   );
   const { gameID, playerID } = useAppSelector(getGameInfo, shallowEqual);
-  const [joinGameMutation, joinGameMutationData] = useJoinGameMutation();
-
-  const getTurnOrderIndicator = (
-    preferredTurnOrder: string | null | undefined
-  ) => {
-    if (!preferredTurnOrder) return null;
-
-    if (preferredTurnOrder === '1st') {
-      return '1st';
-    } else if (preferredTurnOrder === '2nd') {
-      return '2nd';
-    }
-    return null;
-  };
+  const [joinGameMutation] = useJoinGameMutation();
 
   const handleMatchupClick = async (matchupID: string) => {
     if (isReadied) return;
@@ -73,63 +75,384 @@ const Matchups = ({
     }
   };
 
-  const sortedMatchups = [...(gameLobby?.matchups ?? [])];
-  sortedMatchups.sort((a, b) => a.name.localeCompare(b.name));
+  // Slug → hero entry, sourced from backend `legalHeroes`. Used for hero-tile
+  // rendering and the discovery grid. Already format-filtered + ban-filtered
+  // server-side (via CardClass + isBannedInFormat in JoinGame.php), so any
+  // entry here is implicitly a legal hero in the current format.
+  const normalizeSlug = (s: string) => s.replace(/[/!]/g, '');
 
-  const filteredMatchups = sortedMatchups.filter((matchup) =>
-    matchup.name.toLowerCase().includes(searchTerm.toLowerCase())
+  const HERO_BY_SLUG = useMemo(() => {
+    const map = new Map<string, ResolvedHero>();
+    for (const h of gameLobby?.legalHeroes ?? []) {
+      map.set(normalizeSlug(h.heroId), { id: h.heroId, name: h.name, class: h.class });
+    }
+    return map;
+  }, [gameLobby?.legalHeroes]);
+
+  // Resolve a saved matchup to a hero entry.
+  //
+  // Bazaar: matchupId IS the hero slug (e.g. "bravo_showstopper").
+  // Fabrary: matchupId is a ULID, but hero-backed matchups include
+  //   heroIdenfitiers (Fabrary's typo) with the slug in hyphen form.
+  // FabDB/other: no reliable hero signal — renders as button.
+  const resolveHero = (m: Matchup): ResolvedHero | null => {
+    const bySlug = HERO_BY_SLUG.get(normalizeSlug(m.matchupId));
+    if (bySlug) return bySlug;
+    const fabId = m.heroIdenfitiers?.[0];
+    if (fabId) return HERO_BY_SLUG.get(normalizeSlug(fabId.replace(/-/g, '_'))) ?? null;
+    return null;
+  };
+
+  // Partition saved matchups into hero-backed (rendered as portrait) vs
+  // custom-named (rendered as full-width button). Banned-hero matchups
+  // (slug not in legalHeroes) naturally fall into customs and render as
+  // buttons — their data is preserved, just visually treated as a profile.
+  const { savedHeroMatchups, customMatchups } = useMemo(() => {
+    const heroes: { hero: ResolvedHero; matchup: Matchup }[] = [];
+    const customs: Matchup[] = [];
+    for (const m of gameLobby?.matchups ?? []) {
+      const hero = resolveHero(m);
+      if (hero) heroes.push({ hero, matchup: m });
+      else customs.push(m);
+    }
+    return { savedHeroMatchups: heroes, customMatchups: customs };
+  }, [gameLobby?.matchups, HERO_BY_SLUG, isBazaarDeck]);
+
+  // Format-legal heroes that AREN'T already saved (the discovery grid for
+  // Bazaar). Sourced exclusively from the backend's `legalHeroes` list —
+  // it has already applied the format-tier and ban filters via CardClass()
+  // and isBannedInFormat(). When the field isn't present on the response
+  // (older backend), the discovery grid simply doesn't render — better than
+  // guessing format legality on the FE.
+  const unsavedHeroes = useMemo(() => {
+    if (!isBazaarDeck) return [];
+    const fromBackend = gameLobby?.legalHeroes;
+    if (!fromBackend || fromBackend.length === 0) return [];
+    const savedHeroIds = new Set(savedHeroMatchups.map((s) => s.hero.id));
+    return fromBackend
+      .filter((h) => !savedHeroIds.has(h.heroId))
+      .map((h) => ({
+        matchupId: h.heroId,
+        name: h.name,
+        class: h.class,
+        preferredTurnOrder: null as string | null,
+        notes: null as string | null,
+        hasData: false,
+      }));
+  }, [savedHeroMatchups, isBazaarDeck, gameLobby?.legalHeroes]);
+
+  const matchesSearch = (s: string) =>
+    s.toLowerCase().includes(searchTerm.toLowerCase());
+
+  // When the opponent's hero is known, sort the saved hero matchups so the one
+  // targeting that hero is first (upper-left). Subsequent ordering is preserved.
+  const sortedSavedHeroMatchups = useMemo(() => {
+    const theirHero = gameLobby?.theirHero?.toLowerCase();
+    if (!theirHero || theirHero === 'cardback') return savedHeroMatchups;
+    const idx = savedHeroMatchups.findIndex(
+      ({ matchup, hero }) =>
+        matchup.matchupId.toLowerCase() === theirHero ||
+        hero.id.toLowerCase() === theirHero
+    );
+    if (idx <= 0) return savedHeroMatchups; // not found, or already first
+    const reordered = [...savedHeroMatchups];
+    const [match] = reordered.splice(idx, 1);
+    reordered.unshift(match);
+    return reordered;
+  }, [savedHeroMatchups, gameLobby?.theirHero]);
+
+  const filteredSavedHeroMatchups = useMemo(
+    () => sortedSavedHeroMatchups.filter(({ matchup, hero }) =>
+      matchesSearch(matchup.name ?? hero.name)
+    ),
+    [sortedSavedHeroMatchups, searchTerm]
   );
 
-  if (sortedMatchups.length > 0) {
-    return (
-      <article className={styles.matchupContainer}>
-        <>
-          <h4>Matchups</h4>
-          <input
-            type="text"
-            placeholder="Search"
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-          />
-          {filteredMatchups.map((matchup, ix) => {
-            const turnOrderIndicator = getTurnOrderIndicator(
-              matchup.preferredTurnOrder
-            );
-            return (
-              <div className={styles.matchups} key={ix}>
-                <MatchupTooltip content={matchup.notes}>
-                  <button
-                    disabled={isUpdating || isReadied}
-                    className={`${styles.matchupButton} ${
-                      selectedMatchupId === matchup.matchupId
-                        ? styles.matchupButtonSelected
-                        : 'outline'
-                    }`}
-                    onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                      e.preventDefault();
-                      handleMatchupClick(matchup.matchupId);
-                    }}
-                  >
-                    <span className={styles.matchupName}>{matchup.name}</span>
-                    {selectedMatchupId === matchup.matchupId && (
-                      <span className={styles.selectedBadge}>Selected</span>
-                    )}
-                    {turnOrderIndicator && (
-                      <span className={styles.turnOrderBadge}>
-                        {turnOrderIndicator}
-                      </span>
-                    )}
-                  </button>
-                </MatchupTooltip>
+  const filteredCustomMatchups = useMemo(
+    () => customMatchups.filter((m) => matchesSearch(m.name ?? m.matchupId)),
+    [customMatchups, searchTerm]
+  );
+
+  const filteredUnsavedHeroes = useMemo(
+    () => unsavedHeroes.filter((h) => matchesSearch(h.name)),
+    [unsavedHeroes, searchTerm]
+  );
+
+  // Group by backend-supplied class (e.g. "RUNEBLADE" -> "Runeblade").
+  // Heroes whose `class` is empty bucket under "Other" as a safety net —
+  // shouldn't happen in normal operation since the backend computes class
+  // via CardClass() for every legal hero.
+  const groupedMatchups = useMemo(() => {
+    const groups: Record<string, typeof filteredUnsavedHeroes> = {};
+    for (const h of filteredUnsavedHeroes) {
+      const cls = h.class
+        ? h.class.charAt(0) + h.class.slice(1).toLowerCase()
+        : 'Other';
+      if (!groups[cls]) groups[cls] = [];
+      groups[cls].push(h);
+    }
+    return Object.keys(groups)
+      .sort((a, b) => {
+        if (a === 'Other') return 1;
+        if (b === 'Other') return -1;
+        return a.localeCompare(b);
+      })
+      .map((cls) => ({ cls, matchups: groups[cls] }));
+  }, [filteredUnsavedHeroes]);
+
+  if ((gameLobby?.matchups ?? []).length === 0) return null;
+
+  return (
+    <article className={styles.matchupContainer}>
+      <div className={styles.matchupHeader}>
+        <h4>Matchups</h4>
+        {onExpandChat && (
+          <button
+            type="button"
+            className={styles.chatToggleBtn}
+            onClick={onExpandChat}
+          >
+            ◂ Chat
+          </button>
+        )}
+      </div>
+      <input
+        type="text"
+        placeholder="Search"
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        className={styles.searchInput}
+      />
+      {isAutoApplyingMatchup && (
+        <p className={styles.autoApplyingStatus}>Applying hero matchup...</p>
+      )}
+      <div className={styles.groupsWrapper}>
+        {(filteredSavedHeroMatchups.length > 0 || filteredCustomMatchups.length > 0) && (
+          <div className={styles.classGroup}>
+            <p className={styles.groupHeader}>SAVED PROFILES</p>
+            {filteredSavedHeroMatchups.length > 0 && (
+              <div className={styles.portraitGrid}>
+                {filteredSavedHeroMatchups.map(({ hero, matchup }) => {
+                  const isSelected = selectedMatchupId === matchup.matchupId;
+                  return (
+                    <MatchupTooltip key={matchup.matchupId} content={matchup.notes ?? null}>
+                      <button
+                        type="button"
+                        disabled={isUpdating || isReadied}
+                        className={`${styles.portraitCard} ${isSelected ? styles.portraitCardSelected : ''}`}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          handleMatchupClick(matchup.matchupId);
+                        }}
+                      >
+                        <img
+                          src={generateCroppedImageUrl(normalizeSlug(hero.id))}
+                          alt={matchup.name ?? hero.name}
+                          className={`${styles.portraitImg} ${styles.portraitImgHasData}`}
+                          onError={(e) => {
+                            (e.target as HTMLImageElement).style.opacity = '0';
+                          }}
+                        />
+                        <div className={styles.portraitOverlay}>
+                          <span className={styles.portraitName}>
+                            {matchup.name ?? hero.name}
+                          </span>
+                          {matchup.preferredTurnOrder && (
+                            <span className={styles.turnOrderBadge}>
+                              {matchup.preferredTurnOrder}
+                            </span>
+                          )}
+                        </div>
+                      </button>
+                    </MatchupTooltip>
+                  );
+                })}
               </div>
-            );
-          })}
-        </>
-      </article>
-    );
+            )}
+            {filteredCustomMatchups.length > 0 && (
+              <div className={styles.namedMatchupList}>
+                {filteredCustomMatchups.map((m) => {
+                  const isSelected = selectedMatchupId === m.matchupId;
+                  return (
+                    <MatchupTooltip key={m.matchupId} content={m.notes ?? null}>
+                      <button
+                        type="button"
+                        disabled={isUpdating || isReadied}
+                        className={`${styles.namedMatchupItem} ${isSelected ? styles.namedMatchupSelected : ''}`}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          handleMatchupClick(m.matchupId);
+                        }}
+                      >
+                        <span className={styles.namedMatchupName}>
+                          {m.name ?? m.matchupId}
+                        </span>
+                        {m.preferredTurnOrder && (
+                          <span className={styles.namedMatchupBadge}>
+                            {m.preferredTurnOrder}
+                          </span>
+                        )}
+                      </button>
+                    </MatchupTooltip>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+        {groupedMatchups.map(({ cls, matchups }) => (
+          <div key={cls} className={styles.classGroup}>
+            <p className={styles.groupHeader}>{cls.toUpperCase()}</p>
+            <div className={styles.portraitGrid}>
+              {matchups.map((matchup) => {
+                const isSelected = selectedMatchupId === matchup.matchupId;
+                return (
+                  <MatchupTooltip key={matchup.matchupId} content={matchup.notes}>
+                    <button
+                      type="button"
+                      disabled={isUpdating || isReadied}
+                      className={`${styles.portraitCard} ${isSelected ? styles.portraitCardSelected : ''}`}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        if (!matchup.hasData) {
+                          const rect = (e.currentTarget as HTMLButtonElement).getBoundingClientRect();
+                          setNoDataHero({
+                            id: matchup.matchupId,
+                            name: matchup.name,
+                            anchorRect: rect,
+                          });
+                          return;
+                        }
+                        handleMatchupClick(matchup.matchupId);
+                      }}
+                    >
+                      <img
+                        src={generateCroppedImageUrl(normalizeSlug(matchup.matchupId))}
+                        alt={matchup.name}
+                        className={`${styles.portraitImg} ${matchup.hasData ? styles.portraitImgHasData : ''}`}
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).style.opacity = '0';
+                        }}
+                      />
+                      <div className={styles.portraitOverlay}>
+                        <span className={styles.portraitName}>{matchup.name}</span>
+                        {matchup.preferredTurnOrder && (
+                          <span className={styles.turnOrderBadge}>
+                            {matchup.preferredTurnOrder}
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  </MatchupTooltip>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+      {noDataHero &&
+        createPortal(
+          <NoDataPopover
+            hero={noDataHero}
+            onClose={() => setNoDataHero(null)}
+            deckLink={gameLobby?.myDeckLink}
+          />,
+          document.body
+        )}
+    </article>
+  );
+};
+
+const POPOVER_WIDTH = 260;
+const POPOVER_GAP = 10;
+
+const FAB_BAZAAR_DECK_PREFIX = 'https://fabbazaar.app/decks/';
+
+const buildMatchupsLink = (deckLink: string | undefined): string | null => {
+  if (!deckLink) return null;
+  // FaB Bazaar exposes a /matchups subpath; deep-link straight there so the
+  // user lands on the matchup-config page for the hero they just clicked.
+  if (deckLink.startsWith(FAB_BAZAAR_DECK_PREFIX)) {
+    const trimmed = deckLink.split('?')[0].replace(/\/+$/, '');
+    return `${trimmed}/matchups`;
+  }
+  // Other deckbuilders: just open the deck page (we don't know if/where they
+  // expose a matchups view).
+  return deckLink;
+};
+
+const NoDataPopover = ({
+  hero,
+  onClose,
+  deckLink,
+}: {
+  hero: { id: string; name: string; anchorRect: DOMRect };
+  onClose: () => void;
+  deckLink?: string;
+}) => {
+  const { anchorRect } = hero;
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  // Anchor to the left of the hero card by default; flip to right side if no room
+  let left = anchorRect.left - POPOVER_WIDTH - POPOVER_GAP;
+  let placement: 'left' | 'right' = 'left';
+  if (left < 8) {
+    left = anchorRect.right + POPOVER_GAP;
+    placement = 'right';
+  }
+  if (left + POPOVER_WIDTH > vw - 8) {
+    left = vw - POPOVER_WIDTH - 8;
   }
 
-  return null;
+  // Vertically center on the anchor, but keep within viewport
+  let top = anchorRect.top + anchorRect.height / 2;
+  const estimatedHeight = 150;
+  top = Math.max(8 + estimatedHeight / 2, Math.min(top, vh - 8 - estimatedHeight / 2));
+
+  return (
+    <>
+      <div className={styles.noDataBackdrop} onClick={onClose} />
+      <div
+        className={styles.noDataPopover}
+        style={{
+          top: `${top}px`,
+          left: `${left}px`,
+          transform: 'translateY(-50%)',
+        }}
+        data-placement={placement}
+      >
+        <button
+          type="button"
+          className={styles.noDataCloseX}
+          onClick={onClose}
+          aria-label="Close"
+        >
+          ×
+        </button>
+        <p className={styles.noDataTitle}>No matchup saved</p>
+        <p className={styles.noDataBody}>
+          No deck profile against <strong>{hero.name}</strong>. Save one in
+          your deckbuilder to auto-apply sideboard adjustments.
+        </p>
+        {(() => {
+          const matchupsHref = buildMatchupsLink(deckLink);
+          if (!matchupsHref) return null;
+          const isBazaar = matchupsHref.startsWith(FAB_BAZAAR_DECK_PREFIX);
+          return (
+            <a
+              href={matchupsHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.noDataLearnLink}
+            >
+              {isBazaar ? 'Configure matchup ↗' : 'Open deck ↗'}
+            </a>
+          );
+        })()}
+      </div>
+    </>
+  );
 };
 
 export default Matchups;

--- a/src/routes/game/lobby/components/matchups/Matchups.tsx
+++ b/src/routes/game/lobby/components/matchups/Matchups.tsx
@@ -93,12 +93,12 @@ const Matchups = ({
   //
   // Bazaar: matchupId IS the hero slug (e.g. "bravo_showstopper").
   // Fabrary: matchupId is a ULID, but hero-backed matchups include
-  //   heroIdenfitiers (Fabrary's typo) with the slug in hyphen form.
+  //   heroIdentifiers with the slug in hyphen form.
   // FabDB/other: no reliable hero signal — renders as button.
   const resolveHero = (m: Matchup): ResolvedHero | null => {
     const bySlug = HERO_BY_SLUG.get(normalizeSlug(m.matchupId));
     if (bySlug) return bySlug;
-    const fabId = m.heroIdenfitiers?.[0];
+    const fabId = m.heroIdentifiers?.[0];
     if (fabId) return HERO_BY_SLUG.get(normalizeSlug(fabId.replace(/-/g, '_'))) ?? null;
     return null;
   };

--- a/src/routes/game/lobby/components/stickyFooter/StickyFooter.module.css
+++ b/src/routes/game/lobby/components/stickyFooter/StickyFooter.module.css
@@ -1,295 +1,322 @@
-/* ── Shell ────────────────────────────────────── */
 .stickyFooter {
   position: fixed;
   bottom: 0;
   right: 0;
   left: 0;
   background-color: var(--theme-card-background, #1e2329);
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  --sticky-footer-height: auto;
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 0 0.5rem;
+  border-radius: 0;
   z-index: 1000;
   box-shadow:
-    0 -8px 24px rgba(0, 0, 0, 0.4),
-    0 -2px 6px rgba(0, 0, 0, 0.2);
+    0 -10px 30px rgba(0, 0, 0, 0.35),
+    0 -2px 8px rgba(0, 0, 0, 0.2);
 }
 
 .dynamicContainer {
-  padding: 0;
-}
-
-/* ── Main row ─────────────────────────────────── */
-.mainRow {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 3em auto 3em 1fr auto auto;
+  padding: 1em 0.5em;
+  gap: 0.5em;
+  grid-template-areas: 'clipboard start content . deckCount submit';
   align-items: center;
-  padding: 0.5rem 0.75rem;
-  gap: 0.5rem;
-  min-height: 44px;
 }
 
-/* ── Left: sync toggle ────────────────────────── */
-.syncSection {
+.footerStart {
+  grid-area: start;
+}
+
+.footerContent {
+  grid-area: deckCount;
+}
+
+.deckCount {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  justify-content: flex-start;
-  min-width: 0;
-}
-
-.syncActive,
-.syncPassive {
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  border-radius: 999px;
-  padding: 0.15rem 0.5rem;
   white-space: nowrap;
 }
 
-.syncActive {
+@keyframes pulseWarning {
+  0%, 100% { opacity: 0.45; }
+  50% { opacity: 1; }
+}
+
+.deckErrorIcon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  color: #E67E22;
+  font-size: 1.1em;
+  animation: pulseWarning 1.6s ease-in-out infinite;
+  cursor: default;
+  flex-shrink: 0;
+}
+
+.deckErrorIcon:hover {
+  animation: none;
+  opacity: 1;
+}
+
+.deckErrorTooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(20, 24, 28, 0.97);
+  border: 1px solid rgba(230, 126, 34, 0.55);
+  color: #E67E22;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.3rem 0.65rem;
+  border-radius: 5px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  z-index: 100;
+}
+
+.deckErrorIcon:hover .deckErrorTooltip {
+  opacity: 1;
+}
+
+.buttonHolder {
+  grid-area: submit;
+  display: flex;
+  flex-direction: row;
+  gap: 0.5em;
+}
+
+.buttonClass {
+  margin-bottom: 0;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.buttonClassLeave {
+  margin-bottom: 0;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.buttonClassLeave:hover {
+  border-color: black;
+  background-color: var(--alarm);
+  color: black;
+  transition: 0.7s;
+}
+
+
+.clipboardButtonHolder {
+  grid-area: clipboard;
+}
+
+.labelText {
+  display: inline;
+}
+
+.labelTextLong {
+  display: inline;
+}
+
+.labelTextShort {
+  display: none;
+}
+
+.icon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 1em;
+  height: 1em;
+  font-size: 1.3em;
+  margin-left: 0.1em;
+  pointer-events: auto;
+  user-select: none;
+  cursor: pointer;
+}
+
+.syncInline {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: 0.35rem;
+  min-width: 0;
+}
+
+.syncInlineActive,
+.syncInlinePassive {
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+  padding: 0.14rem 0.45rem;
+  white-space: nowrap;
+}
+
+.syncInlineActive {
   background: rgba(145, 110, 34, 0.22);
   border: 1px solid rgba(214, 180, 85, 0.55);
   color: #f1de9f;
 }
 
-.syncPassive {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  color: rgba(255, 255, 255, 0.45);
+.syncInlinePassive {
+  background: color-mix(in srgb, var(--theme-warning) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--theme-warning) 50%, transparent);
+  color: var(--theme-warning);
 }
 
-.syncPassiveLink {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  color: rgba(255, 255, 255, 0.45);
+.syncInlineText {
   font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  border-radius: 999px;
-  padding: 0.15rem 0.5rem;
-  white-space: nowrap;
-  text-decoration: none;
-}
-
-.syncPassiveLink:hover {
-  color: rgba(255, 255, 255, 0.75);
-  border-color: rgba(255, 255, 255, 0.25);
-}
-
-.syncLink {
-  font-size: 0.67rem;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.4);
+  color: rgba(255, 255, 255, 0.9);
+  white-space: nowrap;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.syncInlineLink {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.92);
   text-decoration: underline;
   text-underline-offset: 2px;
   white-space: nowrap;
 }
 
-.syncLink:hover {
-  color: rgba(255, 255, 255, 0.75);
+.syncInlineLink:hover {
+  color: #fff;
 }
 
-.iconButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  appearance: none;
-  width: 34px;
-  height: 34px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  color: rgba(255, 255, 255, 0.45);
-  padding: 0;
-  margin: 0;
-  cursor: pointer;
-  font-size: 18px;
-  line-height: 1;
-  transition: all 0.15s ease;
-  flex-shrink: 0;
-}
-
-.iconButton:hover {
-  background: rgba(255, 255, 255, 0.1);
-  color: rgba(255, 255, 255, 0.8);
-  border-color: rgba(255, 255, 255, 0.25);
-  transform: none;
-  box-shadow: none;
-}
-
-.iconButton > svg {
-  display: block;
-  width: 1em;
-  height: 1em;
-  flex-shrink: 0;
-}
-
-.iconButtonCopied {
-  color: #4ade80;
-  border-color: #4ade80;
-  background: rgba(74, 222, 128, 0.1);
-}
-
-.iconButtonCopied:hover {
-  color: #4ade80;
-  border-color: #4ade80;
-  background: rgba(74, 222, 128, 0.15);
-}
-
-/* ── Center: deck count ───────────────────────── */
-.deckSection {
-  display: flex;
-  flex-direction: row;
-  align-items: baseline;
-  gap: 0.35rem;
-}
-
-.deckNumber {
-  font-size: 1.25rem;
-  font-weight: 800;
-  line-height: 1;
-  color: rgba(255, 255, 255, 0.85);
-  transition: color 0.3s ease;
-}
-
-.deckMeta {
-  font-size: 0.68rem;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.35);
-  white-space: nowrap;
-  letter-spacing: 0.02em;
-  transition: color 0.3s ease;
-}
-
-.deckReady .deckNumber {
-  color: #4caf80;
-}
-
-.deckReady .deckMeta {
-  color: rgba(76, 175, 128, 0.65);
-}
-
-/* ── Right: action buttons ────────────────────── */
-.actionSection {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  justify-content: flex-end;
-}
-
-.confirmButton {
-  font-weight: 700;
-  font-size: 0.88rem;
-  padding: 0.45rem 1.1rem;
-  border-radius: 6px;
-  border: none;
-  margin: 0;
-  white-space: nowrap;
-  transition: all 0.2s ease;
-  width: auto;
-  cursor: pointer;
-}
-
-.confirmReady {
-  background: var(--theme-primary, #d4af37);
-  color: #000;
-}
-
-.confirmReady:hover {
-  background: var(--theme-primary-hover, #e5c443);
-  box-shadow: 0 2px 10px rgba(212, 175, 55, 0.35);
-}
-
-.confirmDisabled {
-  background: rgba(255, 255, 255, 0.06);
-  color: rgba(255, 255, 255, 0.25);
-  cursor: not-allowed;
-  border: 1px solid rgba(255, 255, 255, 0.08) !important;
-}
-
-.editButton {
-  font-weight: 600;
-  font-size: 0.88rem;
-  padding: 0.45rem 1.1rem;
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  margin: 0;
-  white-space: nowrap;
-  width: auto;
-  cursor: pointer;
-  transition: background 0.15s ease;
-}
-
-.editButton:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.13);
-  transform: none;
-  box-shadow: none;
-}
-
-.leaveButton {
-  font-size: 0.88rem;
-  padding: 0.45rem 1.1rem;
-  margin: 0;
-  white-space: nowrap;
-  width: auto;
-}
-
-/* ── Alarm row ────────────────────────────────── */
-.alarmRow {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.3rem 0.75rem 0.4rem;
-  font-size: 0.82rem;
-  font-weight: 600;
-  color: #e67e22;
-  border-top: 1px solid rgba(230, 126, 34, 0.2);
-  background: rgba(230, 126, 34, 0.06);
-  animation: alarmSlideIn 0.18s ease;
-}
-
-.alarmIcon {
-  flex-shrink: 0;
-}
-
-@keyframes alarmSlideIn {
-  from {
-    opacity: 0;
-    transform: translateY(-3px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* ── Widescreen tweaks ────────────────────────── */
-@media (min-width: 769px) {
-  .mainRow {
-    padding: 0.5rem 0.9rem;
-    gap: 0.75rem;
+/* Tablet and smaller screens */
+@media (max-width: 1024px) {
+  .stickyFooter > .dynamicContainer > div:first-child {
+    flex: none;
+    gap: 1em !important;
   }
 
-  .confirmButton {
-    padding: 0.5rem 1.35rem;
+  .dynamicContainer {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0.6em 0.3em;
+    gap: 0.3em;
+    align-items: center;
+    justify-content: flex-start;
   }
 
-  /* Alarm shrinks to a compact inline badge, no full-width bar */
-  .alarmRow {
+  .labelText {
+    display: inline;
+    font-size: 0.9em;
+  }
+
+  .footerContent {
+    font-size: 0.9em;
+    white-space: nowrap;
+    flex: 1;
+    text-align: right;
+    min-width: 60px;
+    margin-right: 0.1em;
+  }
+
+  .buttonHolder {
+    display: flex;
+    flex-direction: row;
+    gap: 0.2em;
+    flex: 0 0 auto;
+    margin-left: 0;
+  }
+
+  .buttonClass {
+    font-size: 0.8em;
+    padding: 0.4rem 0.6rem;
+    white-space: nowrap;
     width: auto;
-    align-self: center;
-    border-top: none;
-    border: 1px solid rgba(230, 126, 34, 0.35);
-    border-radius: 6px;
-    margin: 0 0.9rem 0.4rem;
-    padding: 0.2rem 0.65rem;
-    font-size: 0.8rem;
-    animation: none;
+  }
+
+  .syncInlineText {
+    max-width: 150px;
   }
 }
 
-/* ── Spacer ───────────────────────────────────── */
+/* Mobile screens */
+@media (max-width: 480px) {
+  .stickyFooter > .dynamicContainer > div:first-child {
+    flex: none;
+    gap: 0.5em !important;
+  }
+
+  .dynamicContainer {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0.4em 0.2em;
+    gap: 0.1em;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  .labelTextLong {
+    display: none;
+  }
+
+  .labelTextShort {
+    display: none;
+  }
+
+  .buttonHolder {
+    display: flex;
+    flex-direction: row;
+    gap: 0.1em;
+    flex: 0 0 auto;
+  }
+
+  .buttonClass {
+    font-size: 0.75em;
+    padding: 0.35rem 0.4rem;
+    white-space: nowrap;
+    width: auto;
+  }
+
+  .buttonClassLeave {
+    font-size: 0.75em;
+    padding: 0.35rem 0.4rem;
+    white-space: nowrap;
+  }
+
+  .footerContent {
+    font-size: 0.8em;
+    white-space: nowrap;
+    flex: 1;
+    text-align: center;
+    min-width: 50px;
+  }
+
+  .alarm {
+    font-size: 0.8rem;
+  }
+
+  .stickyFooter {
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+  }
+
+  .syncInline {
+    margin-left: 0.15rem;
+    gap: 0.25rem;
+  }
+
+  .syncInlineText {
+    display: none;
+  }
+
+  .syncInlineLink {
+    font-size: 0.66rem;
+  }
+}
+
+/* Spacer to account for sticky footer */
 .spacer {
   height: var(--sticky-footer-height, 80px);
 }

--- a/src/routes/game/lobby/components/stickyFooter/StickyFooter.tsx
+++ b/src/routes/game/lobby/components/stickyFooter/StickyFooter.tsx
@@ -1,10 +1,10 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { useFormikContext } from 'formik';
 import { FaExclamationCircle } from 'react-icons/fa';
 import { DeckResponse } from 'interface/API/GetLobbyInfo.php';
 import styles from './StickyFooter.module.css';
 import classNames from 'classnames';
-import { HiClipboardCopy, HiClipboardCheck } from 'react-icons/hi';
+import { HiClipboardCopy } from 'react-icons/hi';
 import { MdGames } from 'react-icons/md';
 
 export type DeckSize = {
@@ -42,15 +42,10 @@ const StickyFooter = ({
 }: DeckSize) => {
   const { errors, values, isValid } = useFormikContext<DeckResponse>();
   const footerRef = useRef<HTMLDivElement>(null);
-  const [copied, setCopied] = useState(false);
-  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   let errorArray = [] as string[];
-  for (const [, value] of Object.entries(errors)) {
+  for (const [key, value] of Object.entries(errors)) {
     errorArray.push(String(value));
   }
-
-  const needed = deckSize - values.deck.length;
-  const isConfirmEnabled = isValid && submitSideboard && !needToDoDisclaimer;
 
   // Update CSS custom property with footer height
   useEffect(() => {
@@ -68,160 +63,148 @@ const StickyFooter = ({
 
     updateFooterHeight();
     const timer = setTimeout(updateFooterHeight, 100);
+
+    const observer = footerRef.current
+      ? new ResizeObserver(updateFooterHeight)
+      : null;
+    if (observer && footerRef.current) observer.observe(footerRef.current);
+
     window.addEventListener('resize', updateFooterHeight);
     return () => {
       clearTimeout(timer);
+      observer?.disconnect();
       window.removeEventListener('resize', updateFooterHeight);
     };
   }, []);
 
+  // Call the callback when isValid changes
   useEffect(() => {
     onIsValidChange?.(isValid);
   }, [isValid, onIsValidChange]);
 
-  const triggerCopiedFeedback = () => {
-    setCopied(true);
-    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
-    copyTimerRef.current = setTimeout(() => setCopied(false), 2000);
-  };
-
   const handleClipboardCopy = () => {
-    const text = window.location.href.replace('lobby', 'join');
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text)
-        .then(triggerCopiedFeedback)
-        .catch(() => {
-          fallbackCopyToClipboard(text);
-          triggerCopiedFeedback();
-        });
-    } else {
-      fallbackCopyToClipboard(text);
-      triggerCopiedFeedback();
-    }
+    navigator.clipboard.writeText(
+      window.location.href.replace('lobby', 'join')
+    );
   };
 
-  const fallbackCopyToClipboard = (text: string) => {
-    const textarea = document.createElement('textarea');
-    textarea.value = text;
-    textarea.style.position = 'fixed';
-    textarea.style.opacity = '0';
-    document.body.appendChild(textarea);
-    textarea.focus();
-    textarea.select();
-    document.execCommand('copy');
-    document.body.removeChild(textarea);
-  };
-
-  const wrapperClass = classNames(styles.dynamicContainer, 'container');
-  const leaveClass = classNames(styles.leaveButton, 'outline secondary');
-
-  const deckMetaText = isConfirmEnabled
-    ? `/${deckSize}\u00a0\u00b7\u00a0\u2713\u00a0ready`
-    : needed > 0
-    ? `/${deckSize}\u00a0\u00b7\u00a0need\u00a0${needed}\u00a0more`
-    : `/${deckSize}`;
+  const dynamicContainer = classNames(styles.dynamicContainer, 'container');
+  const leaveLobby = classNames(styles.buttonClassLeave, 'outline secondary');
 
   return (
     <div className={styles.stickyFooter} ref={footerRef}>
-      <div className={wrapperClass}>
-        {/* Main action row: sync | deck count | confirm */}
-        <div className={styles.mainRow}>
-          {/* Left: copy + sync status */}
-          <div className={styles.syncSection}>
-            <button
-              className={classNames(styles.iconButton, { [styles.iconButtonCopied]: copied })}
-              onClick={handleClipboardCopy}
-              type="button"
-              title={copied ? 'Copied!' : 'Copy invite link'}
-            >
-              {copied ? <HiClipboardCheck /> : <HiClipboardCopy />}
-            </button>
-            {!syncEnabled && (
-              syncLearnMoreUrl ? (
+      <div className={dynamicContainer}>
+        <div
+          style={{
+            display: 'flex',
+            gap: '2rem',
+            alignItems: 'center',
+            flex: 1
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <div className={styles.clipboardButtonHolder}>
+              <button
+                className={styles.buttonClass}
+                onClick={handleClipboardCopy}
+                type="button"
+                title="Copy invite link"
+              >
+                <div className={styles.icon}>
+                  <HiClipboardCopy />
+                </div>
+              </button>
+            </div>
+            <div className={styles.syncInline}>
+              <span
+                className={syncEnabled ? styles.syncInlineActive : styles.syncInlinePassive}
+                title={syncStatusText}
+              >
+                {syncEnabled ? 'Sync On' : 'Sync Off'}
+              </span>
+              {syncStatusText && (
+                <span className={styles.syncInlineText}>{syncStatusText}</span>
+              )}
+              {syncLearnMoreUrl && !syncEnabled && (
                 <a
                   href={syncLearnMoreUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={styles.syncPassiveLink}
-                  title={syncStatusText}
+                  className={styles.syncInlineLink}
                 >
-                  Sync off
+                  Read more
                 </a>
-              ) : (
-                <span
-                  className={styles.syncPassive}
-                  title={syncStatusText}
-                >
-                  Sync off
-                </span>
-              )
-            )}
-            {onSendInviteClick && isWidescreen && (
+              )}
+            </div>
+          </div>
+          {onSendInviteClick && (
+            <div
+              style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}
+            >
+              <span
+                style={{ whiteSpace: 'nowrap' }}
+                className={styles.labelTextLong}
+              >
+                Send Friends Invite
+              </span>
+              <span
+                style={{ whiteSpace: 'nowrap' }}
+                className={styles.labelTextShort}
+              >
+                Send Invite
+              </span>
               <button
-                className={styles.iconButton}
+                className={styles.buttonClass}
                 onClick={onSendInviteClick}
                 type="button"
                 title="Send invite to friend"
               >
-                <MdGames />
+                <div className={styles.icon}>
+                  <MdGames />
+                </div>
               </button>
+            </div>
+          )}
+        </div>
+        <div className={styles.footerContent}>
+          <div className={styles.deckCount}>
+            {!isValid && errorArray.length > 0 && (
+              <span className={styles.deckErrorIcon}>
+                <FaExclamationCircle />
+                <span className={styles.deckErrorTooltip}>{errorArray[0]}</span>
+              </span>
             )}
-          </div>
-
-          {/* Center: deck count */}
-          <div
-            className={`${styles.deckSection} ${
-              isConfirmEnabled ? styles.deckReady : ''
-            }`}
-          >
-            <span className={styles.deckNumber}>{values.deck.length}</span>
-            <span className={styles.deckMeta}>{deckMetaText}</span>
-          </div>
-
-          {/* Right: confirm / edit + optional leave */}
-          <div className={styles.actionSection}>
-            {canUnreadySideboard ? (
-              <button
-                className={styles.editButton}
-                type="button"
-                disabled={isUnreadyLoading || needToDoDisclaimer}
-                onClick={onUnreadySideboard}
-              >
-                Edit Deck
-              </button>
-            ) : (
-              <button
-                className={`${styles.confirmButton} ${
-                  isConfirmEnabled
-                    ? styles.confirmReady
-                    : styles.confirmDisabled
-                }`}
-                type="submit"
-                aria-busy={isSubmitting}
-                disabled={!isConfirmEnabled || isSubmitting}
-              >
-                {isSubmitting
-                  ? 'Submitting\u2026'
-                  : isWidescreen
-                  ? 'Confirm Deck'
-                  : 'Confirm'}
-              </button>
-            )}
-            {isWidescreen && (
-              <button className={leaveClass} onClick={handleLeave}>
-                Leave
-              </button>
-            )}
+            Deck {values.deck.length}/{deckSize}
           </div>
         </div>
-
-        {/* Alarm row — slides in only when deck is invalid */}
-        {!isValid && errorArray[0] && (
-          <div className={styles.alarmRow}>
-            <FaExclamationCircle className={styles.alarmIcon} />
-            <span>{errorArray[0]}</span>
-          </div>
-        )}
+        <div className={styles.buttonHolder}>
+          {canUnreadySideboard ? (
+            <button
+              className={styles.buttonClass}
+              type="button"
+              disabled={isUnreadyLoading || needToDoDisclaimer}
+              onClick={onUnreadySideboard}
+            >
+              {'Edit Deck'}
+            </button>
+          ) : (
+            <button
+              className={styles.buttonClass}
+              type="submit"
+              aria-busy={isSubmitting}
+              disabled={
+                isValid === false || !submitSideboard || needToDoDisclaimer || isSubmitting
+              }
+            >
+              {isSubmitting ? 'Submitting...' : 'Confirm Deck'}
+            </button>
+          )}
+          {isWidescreen && (
+            <button className={leaveLobby} onClick={handleLeave}>
+              Leave
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Re-applies the lobby redesign from PR #729 with the matchup resolution bug fixed, plus polish from review feedback.

**Root cause of original revert:** `resolveHero()` matched Fabrary matchup profile names against `HEROES_OF_RATHE` labels. A profile named "Bravo" matched young Bravo (WTR039), then the `legalSet` filter silently dropped it because `WTR039`/`"bravo"` was not in the CC legal list (which has `bravo_showstopper`/`"bravo showstopper"`).

**Fix:** Slug-based resolution only — no name matching, no fuzzy matching.
- **Bazaar:** `matchupId` is the canonical hero slug, matched directly against backend `legalHeroes`
- **Fabrary:** uses `heroIdentifiers[0]` (normalized hyphen to underscore) when present; falls back to fuzzy name matching for profiles without `heroIdentifiers`
- **Other deckbuilders:** matchups render as buttons (no reliable hero signal)
- Auto-apply uses the same cascading strategy: `heroIdentifiers` then slug then fuzzy name fallback

**Lobby redesign:**
- Matchups panel shows hero portraits in a grid (grouped by class for unsaved heroes)
- Compact chat sidebar with quick-chat presets when matchups are the primary view
- Chat expand/collapse toggle between full chat and matchups
- Bottom bar with Matchups + Hand Probabilities buttons
- NoDataPopover for unsaved hero matchups with link to configure in deckbuilder
- Normalizes `/` and `!` in slugs for image URLs (fixes Dash I/O and Arakni 5L!p3d portraits)

**Update:** Now uses the corrected `heroIdentifiers` field spelling.