### PR TITLE
feat: allow unmasking when inputting passwords

### DIFF
--- a/src/routes/user/login/components/LoginForm.tsx
+++ b/src/routes/user/login/components/LoginForm.tsx
@@ -13,6 +13,7 @@ import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { loginValidationSchema, LoginValidationType } from './validation';
 import { FaExclamationCircle } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
+import { PasswordInput } from './PasswordInput';
 
 const getLoginBody = ({
   userID,
@@ -173,15 +174,10 @@ export const LoginForm = () => {
             <div className={styles.fieldError}>{errors.userID?.message}</div>
           )}
           <label htmlFor="password">{t('USER.LOGIN.PASSWORD')}</label>
-          <input
-            type="password"
-            placeholder="********"
-            {...register('password')}
-            aria-invalid={errors.password?.message ? 'true' : undefined}
+          <PasswordInput
+            register={register}
+            errorMessage={errors.password?.message}
           />
-          {errors.password?.message && (
-            <div className={styles.fieldError}>{errors.password?.message}</div>
-          )}
           <input
             id="rememberMe"
             type="checkbox"

--- a/src/routes/user/login/components/PasswordInput.module.css
+++ b/src/routes/user/login/components/PasswordInput.module.css
@@ -1,0 +1,45 @@
+.passwordContainer {
+  display: flex;
+  align-items: center;
+  column-gap: 8px;
+  padding: 0 var(--form-element-spacing-horizontal);
+  margin-bottom: var(--spacing);
+
+  /* Copy styling from input elements */
+  background-color: var(--theme-form-background, #33383d) !important;
+  color: var(--theme-text, #f4eded) !important;
+  caret-color: var(--theme-text, #f4eded) !important;
+  border: var(--border-width) solid var(--theme-form-border, #797c80);
+  border-radius: var(--border-radius);
+  outline: none;
+}
+
+.passwordContainer:focus-within {
+  background-color: var(--theme-form-active, #33383d) !important;
+  border-color: var(--theme-primary, #d4af37) !important;
+  box-shadow: 0 0 0 3px var(--theme-primary-focus, rgba(212, 175, 55, 0.1)) !important;
+}
+
+.passwordContainer .passwordInput {
+  /* Remove styling from global input and just rely on the parent */
+  margin-bottom: 0 !important;
+  padding: 0 !important;
+  border: none;
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+.passwordContainer .passwordInput:focus {
+  /* Remove styling from global input and just rely on the parent */
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+.passwordContainer .passwordInput[aria-invalid] {
+  padding-right: calc(var(--form-element-spacing-horizontal) + 1.5rem) !important;
+}
+
+.fieldError {
+  color: red;
+  text-align: center;
+}

--- a/src/routes/user/login/components/PasswordInput.tsx
+++ b/src/routes/user/login/components/PasswordInput.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import styles from './PasswordInput.module.css';
+import { FaRegEye, FaRegEyeSlash } from 'react-icons/fa';
+import { UseFormRegister } from 'react-hook-form';
+
+interface Props {
+  register: UseFormRegister<any>;
+  autoComplete?: string;
+  errorMessage?: string;
+}
+
+export const PasswordInput = (props: Props) => {
+  const [maskPassword, setMaskPassword] = useState(true);
+
+  return (
+    <>
+      <div className={styles.passwordContainer}>
+        <input
+          id="password"
+          type={maskPassword ? 'password' : 'text'}
+          placeholder="********"
+          {...props.register('password')}
+          autoComplete={props.autoComplete}
+          aria-invalid={props.errorMessage ? 'true' : undefined}
+          className={styles.passwordInput}
+        />
+        {maskPassword ? (
+          <FaRegEye onClick={() => setMaskPassword(false)} />
+        ) : (
+          <FaRegEyeSlash onClick={() => setMaskPassword(true)} />
+        )}
+      </div>
+      {props.errorMessage && (
+        <div className={styles.fieldError}>{props.errorMessage}</div>
+      )}
+    </>
+  );
+};

--- a/src/routes/user/login/components/ResetPasswordForm.tsx
+++ b/src/routes/user/login/components/ResetPasswordForm.tsx
@@ -9,6 +9,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { toast } from 'react-hot-toast';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { useTranslation } from 'react-i18next';
+import { PasswordInput } from './PasswordInput';
 
 export const ResetPasswordForm = () => {
   const navigate = useNavigate();
@@ -64,16 +65,10 @@ export const ResetPasswordForm = () => {
       <article className={styles.formContainer}>
         <form onSubmit={handleSubmit(onSubmit)} ref={parent}>
           <label htmlFor="password">{t('USER.LOGIN.PASSWORD')}</label>
-          <input
-            id="password"
-            type="password"
-            placeholder="********"
-            {...register('password')}
-            aria-invalid={errors.password?.message ? 'true' : undefined}
+          <PasswordInput
+            register={register}
+            errorMessage={errors.password?.message}
           />
-          {errors.password?.message && (
-            <div className={styles.fieldError}>{errors.password?.message}</div>
-          )}
           <label htmlFor="passwordRepeat">
             {t('USER.LOGIN.CONFIRM_PASSWORD')}
           </label>

--- a/src/routes/user/login/components/SignUpForm.tsx
+++ b/src/routes/user/login/components/SignUpForm.tsx
@@ -10,6 +10,7 @@ import useAuth from 'hooks/useAuth';
 import { toast } from 'react-hot-toast';
 import { useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
+import { PasswordInput } from './PasswordInput';
 
 export const SignUpForm = () => {
   const [disclaimerOpen, setDisclaimerOpen] = useState(false);
@@ -98,17 +99,11 @@ export const SignUpForm = () => {
             <div className={styles.fieldError}>{errors.email?.message}</div>
           )}
           <label htmlFor="password">{t('USER.LOGIN.PASSWORD')}</label>
-          <input
-            id="password"
-            type="password"
-            placeholder="********"
+          <PasswordInput
+            register={register}
             autoComplete="new-password"
-            {...register('password')}
-            aria-invalid={errors.password?.message ? 'true' : undefined}
+            errorMessage={errors.password?.message}
           />
-          {errors.password?.message && (
-            <div className={styles.fieldError}>{errors.password?.message}</div>
-          )}
           <label htmlFor="passwordRepeat">
             {t('USER.LOGIN.CONFIRM_PASSWORD')}
           </label>


### PR DESCRIPTION
Nice to have feature to unmask password when inputting, since sometimes on mobile phones double presses on the keys and it fails to login the user. Added the feature in login, sign-up, and reset password. Also tested both in desktop and mobile.

Preview:
<img width="513" height="592" alt="image" src="https://github.com/user-attachments/assets/69828caa-f92d-4bd4-93a2-2bb78e4b4956" />

<img width="519" height="551" alt="image" src="https://github.com/user-attachments/assets/a2dabd89-2ba2-4110-865c-40c06d7d05ff" />

<img width="512" height="497" alt="image" src="https://github.com/user-attachments/assets/bdb5bf42-a457-4848-a8d1-c43001d97dfb" />
