### PR TITLE
Extend mobile tap-to-preview to board cards

### DIFF
--- a/src/routes/game/components/elements/cardPopUp/CardPopUp.tsx
+++ b/src/routes/game/components/elements/cardPopUp/CardPopUp.tsx
@@ -11,7 +11,6 @@ import { motion, useMotionValue, useSpring, useTransform } from 'framer-motion';
 import { useCookies } from 'react-cookie';
 import { CARD_BACK } from 'features/options/cardBacks';
 import {
-  TAP_PREVIEW_CARD_SELECTOR,
   TAP_TO_PREVIEW_PLAY_COOKIE,
   buildBoardCardSelectionKey,
   clearTapToPreviewSelection,
@@ -166,15 +165,13 @@ export default function CardPopUp({
 
     const onPointerDown = (event: PointerEvent) => {
       const target = event.target as Element | null;
+      // Only the sticky card itself is exempt; any other tap dismisses.
+      // Another card's own click then re-selects / switches preview.
       if (ref.current?.contains(target)) return;
-      const isTapOnPreviewableCard = Boolean(
-        target?.closest?.(TAP_PREVIEW_CARD_SELECTOR)
-      );
       if (
         !shouldDismissStickyPreviewOnOutsideTap({
           enabled: true,
-          selectedKey,
-          isTapOnPreviewableCard
+          selectedKey
         })
       ) {
         return;
@@ -272,9 +269,10 @@ export default function CardPopUp({
     }
   };
 
-  const handleOnClick = (event: React.MouseEvent) => {
+  const handleOnClick = () => {
     if (isTapToPreviewContext()) {
-      event.stopPropagation();
+      // Do not stopPropagation: zone wrappers (pitch/graveyard/banish/deck)
+      // and modal parents (e.g. OtherInput) must still receive the click.
       if (isHidden === true || SKIP_POPUP_CARDS.has(cardNumber)) {
         onClick?.();
         return;
@@ -300,7 +298,6 @@ export default function CardPopUp({
   return (
     <motion.div
       className={containerClass}
-      data-tap-preview-card={cookieEnabled ? 'true' : undefined}
       onClick={handleOnClick}
       onPointerDown={(event) => {
         lastPointerTypeRef.current = event.pointerType;

--- a/src/routes/game/components/elements/cardPopUp/CardPopUp.tsx
+++ b/src/routes/game/components/elements/cardPopUp/CardPopUp.tsx
@@ -62,9 +62,8 @@ type CardPopUpProps = {
   isOpponent?: boolean;
   disableTilt?: boolean;
   disableShadow?: boolean;
-  persistPopUpOnClick?: boolean;
-  /** Hand cards manage tap-to-preview themselves; suppress CardPopUp's copy. */
-  suppressTapToPreview?: boolean;
+  /** Override sticky-selection key (hand cards pass a unique id-based key). */
+  tapPreviewKey?: string;
 };
 
 export default function CardPopUp({
@@ -78,8 +77,7 @@ export default function CardPopUp({
   isOpponent,
   disableTilt,
   disableShadow,
-  persistPopUpOnClick,
-  suppressTapToPreview
+  tapPreviewKey
 }: CardPopUpProps) {
   const ref = useRef<HTMLDivElement>(null);
   const dispatch = useAppDispatch();
@@ -87,23 +85,28 @@ export default function CardPopUp({
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const touchPopupShown = useRef(false);
   const hoverRect = useRef<DOMRect | null>(null);
+  const lastPointerTypeRef = useRef<string | null>(null);
   const popupCardNumber = useAppSelector(
     (state: RootState) => state.game.popup?.popupCard?.cardNumber
   );
 
-  const tapToPreviewEnabled =
-    !suppressTapToPreview &&
-    isTapToPreviewPlayEnabled(cookies[TAP_TO_PREVIEW_PLAY_COOKIE]) &&
-    !supportsHover;
+  const selectionKey =
+    tapPreviewKey ??
+    buildBoardCardSelectionKey({
+      cardNumber,
+      isOpponent
+    });
 
-  const boardSelectionKey = buildBoardCardSelectionKey({
-    cardNumber,
-    isOpponent
-  });
+  const cookieEnabled = isTapToPreviewPlayEnabled(
+    cookies[TAP_TO_PREVIEW_PLAY_COOKIE]
+  );
+
+  const isTapToPreviewContext = () =>
+    cookieEnabled &&
+    (lastPointerTypeRef.current === 'touch' || !supportsHover);
 
   const stickyActive =
-    tapToPreviewEnabled &&
-    getTapToPreviewSelectedCardKey() === boardSelectionKey;
+    cookieEnabled && getTapToPreviewSelectedCardKey() === selectionKey;
 
   const tiltEnabled =
     supportsHover && !disableTilt && cookies.disableCardTilt !== 'true';
@@ -148,7 +151,6 @@ export default function CardPopUp({
     }
   }, [disableTilt, rotateXTarget, rotateYTarget, rotateX, rotateY, intensity]);
 
-  // Dismiss sticky board preview when tapping outside previewable cards.
   useEffect(() => {
     if (!stickyActive) return;
 
@@ -214,14 +216,7 @@ export default function CardPopUp({
   };
 
   const clearPopUpUnlessSticky = () => {
-    // Sticky tap-to-preview keeps the portal up until a confirm play (or
-    // another card switches preview). Without this, touch browsers fire
-    // mouseleave after click and wipe the preview immediately.
-    if (
-      persistPopUpOnClick ||
-      (tapToPreviewEnabled &&
-        getTapToPreviewSelectedCardKey() === boardSelectionKey)
-    ) {
+    if (getTapToPreviewSelectedCardKey() === selectionKey) {
       return;
     }
     dispatch(clearPopUp());
@@ -237,8 +232,8 @@ export default function CardPopUp({
   const handleTouchStart = () => {
     if (longPressTimer.current) clearTimeout(longPressTimer.current);
     touchPopupShown.current = false;
-    // With tap-to-preview, short tap handles sticky preview via onClick.
-    if (tapToPreviewEnabled) return;
+    lastPointerTypeRef.current = 'touch';
+    if (cookieEnabled) return;
     longPressTimer.current = setTimeout(() => {
       longPressTimer.current = null;
       handleMouseEnter();
@@ -261,22 +256,22 @@ export default function CardPopUp({
   };
 
   const handleTouchMove = () => {
-    // Cancel long press if finger moves (user is scrolling)
     if (longPressTimer.current) {
       clearTimeout(longPressTimer.current);
       longPressTimer.current = null;
     }
   };
 
-  const handleOnClick = () => {
-    if (tapToPreviewEnabled) {
+  const handleOnClick = (event: React.MouseEvent) => {
+    if (isTapToPreviewContext()) {
+      event.stopPropagation();
       if (isHidden === true || SKIP_POPUP_CARDS.has(cardNumber)) {
-        if (onClick != null) onClick();
+        onClick?.();
         return;
       }
       const { action, nextSelectedKey } = resolveTapToPreviewPlay({
         enabled: true,
-        cardKey: boardSelectionKey
+        cardKey: selectionKey
       });
       setTapToPreviewSelectedCardKey(nextSelectedKey);
       if (action === 'preview') {
@@ -284,26 +279,23 @@ export default function CardPopUp({
         return;
       }
       clearTapToPreviewSelection();
-      if (onClick != null) {
-        onClick();
-      }
+      onClick?.();
       dispatch(clearPopUp());
       return;
     }
 
-    if (onClick != null) {
-      onClick();
-    }
-    if (!persistPopUpOnClick) {
-      handleMouseLeave();
-    }
+    onClick?.();
+    handleMouseLeave();
   };
 
   return (
     <motion.div
       className={containerClass}
-      data-tap-preview-card={tapToPreviewEnabled ? 'true' : undefined}
+      data-tap-preview-card={cookieEnabled ? 'true' : undefined}
       onClick={handleOnClick}
+      onPointerDown={(event) => {
+        lastPointerTypeRef.current = event.pointerType;
+      }}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onMouseMove={tiltEnabled ? handleMouseMove : undefined}

--- a/src/routes/game/components/elements/cardPopUp/CardPopUp.tsx
+++ b/src/routes/game/components/elements/cardPopUp/CardPopUp.tsx
@@ -1,9 +1,21 @@
-import { useAppDispatch } from 'app/Hooks';
+import { useAppDispatch, useAppSelector } from 'app/Hooks';
+import { RootState } from 'app/Store';
 import { clearPopUp, setPopUp } from 'features/game/GameSlice';
 import { ReactNode, useEffect, useRef } from 'react';
 import { motion, useMotionValue, useSpring, useTransform } from 'framer-motion';
 import { useCookies } from 'react-cookie';
 import { CARD_BACK } from 'features/options/cardBacks';
+import {
+  TAP_PREVIEW_CARD_SELECTOR,
+  TAP_TO_PREVIEW_PLAY_COOKIE,
+  buildBoardCardSelectionKey,
+  clearTapToPreviewSelection,
+  getTapToPreviewSelectedCardKey,
+  isTapToPreviewPlayEnabled,
+  resolveTapToPreviewPlay,
+  setTapToPreviewSelectedCardKey,
+  shouldDismissStickyPreviewOnOutsideTap
+} from '../playerHandCard/tapToPreviewPlay';
 
 const supportsHover =
   typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches;
@@ -51,6 +63,8 @@ type CardPopUpProps = {
   disableTilt?: boolean;
   disableShadow?: boolean;
   persistPopUpOnClick?: boolean;
+  /** Hand cards manage tap-to-preview themselves; suppress CardPopUp's copy. */
+  suppressTapToPreview?: boolean;
 };
 
 export default function CardPopUp({
@@ -64,14 +78,32 @@ export default function CardPopUp({
   isOpponent,
   disableTilt,
   disableShadow,
-  persistPopUpOnClick
+  persistPopUpOnClick,
+  suppressTapToPreview
 }: CardPopUpProps) {
   const ref = useRef<HTMLDivElement>(null);
   const dispatch = useAppDispatch();
-  const [cookies] = useCookies(['disableCardTilt']);
+  const [cookies] = useCookies(['disableCardTilt', TAP_TO_PREVIEW_PLAY_COOKIE]);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const touchPopupShown = useRef(false);
   const hoverRect = useRef<DOMRect | null>(null);
+  const popupCardNumber = useAppSelector(
+    (state: RootState) => state.game.popup?.popupCard?.cardNumber
+  );
+
+  const tapToPreviewEnabled =
+    !suppressTapToPreview &&
+    isTapToPreviewPlayEnabled(cookies[TAP_TO_PREVIEW_PLAY_COOKIE]) &&
+    !supportsHover;
+
+  const boardSelectionKey = buildBoardCardSelectionKey({
+    cardNumber,
+    isOpponent
+  });
+
+  const stickyActive =
+    tapToPreviewEnabled &&
+    getTapToPreviewSelectedCardKey() === boardSelectionKey;
 
   const tiltEnabled =
     supportsHover && !disableTilt && cookies.disableCardTilt !== 'true';
@@ -116,6 +148,33 @@ export default function CardPopUp({
     }
   }, [disableTilt, rotateXTarget, rotateYTarget, rotateX, rotateY, intensity]);
 
+  // Dismiss sticky board preview when tapping outside previewable cards.
+  useEffect(() => {
+    if (!stickyActive) return;
+
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Element | null;
+      if (ref.current?.contains(target)) return;
+      const isTapOnPreviewableCard = Boolean(
+        target?.closest?.(TAP_PREVIEW_CARD_SELECTOR)
+      );
+      if (
+        !shouldDismissStickyPreviewOnOutsideTap({
+          enabled: true,
+          selectedKey: getTapToPreviewSelectedCardKey(),
+          isTapOnPreviewableCard
+        })
+      ) {
+        return;
+      }
+      clearTapToPreviewSelection();
+      dispatch(clearPopUp());
+    };
+
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [stickyActive, dispatch, popupCardNumber]);
+
   const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!tiltEnabled || !ref.current) return;
     let rect = hoverRect.current;
@@ -129,7 +188,7 @@ export default function CardPopUp({
     rotateYTarget.set(((e.clientX - cx) / (rect.width / 2)) * 8);
   };
 
-  const handleMouseEnter = () => {
+  const showPreview = () => {
     if (ref.current === null) {
       return;
     }
@@ -150,11 +209,19 @@ export default function CardPopUp({
     );
   };
 
+  const handleMouseEnter = () => {
+    showPreview();
+  };
+
   const clearPopUpUnlessSticky = () => {
     // Sticky tap-to-preview keeps the portal up until a confirm play (or
     // another card switches preview). Without this, touch browsers fire
     // mouseleave after click and wipe the preview immediately.
-    if (persistPopUpOnClick) {
+    if (
+      persistPopUpOnClick ||
+      (tapToPreviewEnabled &&
+        getTapToPreviewSelectedCardKey() === boardSelectionKey)
+    ) {
       return;
     }
     dispatch(clearPopUp());
@@ -170,6 +237,8 @@ export default function CardPopUp({
   const handleTouchStart = () => {
     if (longPressTimer.current) clearTimeout(longPressTimer.current);
     touchPopupShown.current = false;
+    // With tap-to-preview, short tap handles sticky preview via onClick.
+    if (tapToPreviewEnabled) return;
     longPressTimer.current = setTimeout(() => {
       longPressTimer.current = null;
       handleMouseEnter();
@@ -200,6 +269,28 @@ export default function CardPopUp({
   };
 
   const handleOnClick = () => {
+    if (tapToPreviewEnabled) {
+      if (isHidden === true || SKIP_POPUP_CARDS.has(cardNumber)) {
+        if (onClick != null) onClick();
+        return;
+      }
+      const { action, nextSelectedKey } = resolveTapToPreviewPlay({
+        enabled: true,
+        cardKey: boardSelectionKey
+      });
+      setTapToPreviewSelectedCardKey(nextSelectedKey);
+      if (action === 'preview') {
+        showPreview();
+        return;
+      }
+      clearTapToPreviewSelection();
+      if (onClick != null) {
+        onClick();
+      }
+      dispatch(clearPopUp());
+      return;
+    }
+
     if (onClick != null) {
       onClick();
     }
@@ -211,6 +302,7 @@ export default function CardPopUp({
   return (
     <motion.div
       className={containerClass}
+      data-tap-preview-card={tapToPreviewEnabled ? 'true' : undefined}
       onClick={handleOnClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}

--- a/src/routes/game/components/elements/cardPopUp/CardPopUp.tsx
+++ b/src/routes/game/components/elements/cardPopUp/CardPopUp.tsx
@@ -1,7 +1,12 @@
-import { useAppDispatch, useAppSelector } from 'app/Hooks';
-import { RootState } from 'app/Store';
+import { useAppDispatch } from 'app/Hooks';
 import { clearPopUp, setPopUp } from 'features/game/GameSlice';
-import { ReactNode, useEffect, useRef } from 'react';
+import {
+  ReactNode,
+  useEffect,
+  useId,
+  useRef,
+  useSyncExternalStore
+} from 'react';
 import { motion, useMotionValue, useSpring, useTransform } from 'framer-motion';
 import { useCookies } from 'react-cookie';
 import { CARD_BACK } from 'features/options/cardBacks';
@@ -14,7 +19,8 @@ import {
   isTapToPreviewPlayEnabled,
   resolveTapToPreviewPlay,
   setTapToPreviewSelectedCardKey,
-  shouldDismissStickyPreviewOnOutsideTap
+  shouldDismissStickyPreviewOnOutsideTap,
+  subscribeTapToPreviewSelection
 } from '../playerHandCard/tapToPreviewPlay';
 
 const supportsHover =
@@ -86,15 +92,16 @@ export default function CardPopUp({
   const touchPopupShown = useRef(false);
   const hoverRect = useRef<DOMRect | null>(null);
   const lastPointerTypeRef = useRef<string | null>(null);
-  const popupCardNumber = useAppSelector(
-    (state: RootState) => state.game.popup?.popupCard?.cardNumber
-  );
+  // Per-instance id so two board cards with the same cardNumber stay distinct
+  // (e.g. duplicate permanents / effects). Hand cards pass tapPreviewKey instead.
+  const instanceId = useId();
 
   const selectionKey =
     tapPreviewKey ??
     buildBoardCardSelectionKey({
       cardNumber,
-      isOpponent
+      isOpponent,
+      instanceId
     });
 
   const cookieEnabled = isTapToPreviewPlayEnabled(
@@ -102,11 +109,14 @@ export default function CardPopUp({
   );
 
   const isTapToPreviewContext = () =>
-    cookieEnabled &&
-    (lastPointerTypeRef.current === 'touch' || !supportsHover);
+    cookieEnabled && (lastPointerTypeRef.current === 'touch' || !supportsHover);
 
-  const stickyActive =
-    cookieEnabled && getTapToPreviewSelectedCardKey() === selectionKey;
+  const selectedKey = useSyncExternalStore(
+    subscribeTapToPreviewSelection,
+    getTapToPreviewSelectedCardKey,
+    getTapToPreviewSelectedCardKey
+  );
+  const stickyActive = cookieEnabled && selectedKey === selectionKey;
 
   const tiltEnabled =
     supportsHover && !disableTilt && cookies.disableCardTilt !== 'true';
@@ -163,7 +173,7 @@ export default function CardPopUp({
       if (
         !shouldDismissStickyPreviewOnOutsideTap({
           enabled: true,
-          selectedKey: getTapToPreviewSelectedCardKey(),
+          selectedKey,
           isTapOnPreviewableCard
         })
       ) {
@@ -175,7 +185,7 @@ export default function CardPopUp({
 
     document.addEventListener('pointerdown', onPointerDown);
     return () => document.removeEventListener('pointerdown', onPointerDown);
-  }, [stickyActive, dispatch, popupCardNumber]);
+  }, [stickyActive, selectedKey, dispatch]);
 
   const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!tiltEnabled || !ref.current) return;
@@ -216,7 +226,7 @@ export default function CardPopUp({
   };
 
   const clearPopUpUnlessSticky = () => {
-    if (getTapToPreviewSelectedCardKey() === selectionKey) {
+    if (selectedKey === selectionKey) {
       return;
     }
     dispatch(clearPopUp());
@@ -278,7 +288,6 @@ export default function CardPopUp({
         showPreview();
         return;
       }
-      clearTapToPreviewSelection();
       onClick?.();
       dispatch(clearPopUp());
       return;

--- a/src/routes/game/components/elements/cardPopUp/__tests__/CardPopUp.tapToPreview.test.tsx
+++ b/src/routes/game/components/elements/cardPopUp/__tests__/CardPopUp.tapToPreview.test.tsx
@@ -43,6 +43,9 @@ describe('CardPopUp board tap to preview', () => {
   it('fires onClick immediately when the option is off', () => {
     const onClick = vi.fn();
     const { store } = renderBoardCard({ cookieEnabled: false, onClick });
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'board-card' }), {
+      pointerType: 'touch'
+    });
     fireEvent.click(screen.getByRole('button', { name: 'board-card' }));
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(store.getState().game.popup?.popupOn).not.toBe(true);
@@ -53,6 +56,7 @@ describe('CardPopUp board tap to preview', () => {
     const { store } = renderBoardCard({ cookieEnabled: true, onClick });
     const card = screen.getByRole('button', { name: 'board-card' });
 
+    fireEvent.pointerDown(card, { pointerType: 'touch' });
     fireEvent.click(card);
 
     await waitFor(() => {
@@ -65,6 +69,7 @@ describe('CardPopUp board tap to preview', () => {
     fireEvent.mouseLeave(card);
     expect(store.getState().game.popup?.popupOn).toBe(true);
 
+    fireEvent.pointerDown(card, { pointerType: 'touch' });
     fireEvent.click(card);
 
     await waitFor(() => {
@@ -88,12 +93,16 @@ describe('CardPopUp board tap to preview', () => {
       </CookiesProvider>
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'card-a' }));
+    const cardA = screen.getByRole('button', { name: 'card-a' });
+    const cardB = screen.getByRole('button', { name: 'card-b' });
+    fireEvent.pointerDown(cardA, { pointerType: 'touch' });
+    fireEvent.click(cardA);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR001');
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'card-b' }));
+    fireEvent.pointerDown(cardB, { pointerType: 'touch' });
+    fireEvent.click(cardB);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR002');
     });
@@ -104,7 +113,9 @@ describe('CardPopUp board tap to preview', () => {
   it('dismisses sticky board preview on outside tap', async () => {
     const onClick = vi.fn();
     const { store } = renderBoardCard({ cookieEnabled: true, onClick });
-    fireEvent.click(screen.getByRole('button', { name: 'board-card' }));
+    const card = screen.getByRole('button', { name: 'board-card' });
+    fireEvent.pointerDown(card, { pointerType: 'touch' });
+    fireEvent.click(card);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupOn).toBe(true);
     });

--- a/src/routes/game/components/elements/cardPopUp/__tests__/CardPopUp.tapToPreview.test.tsx
+++ b/src/routes/game/components/elements/cardPopUp/__tests__/CardPopUp.tapToPreview.test.tsx
@@ -24,7 +24,9 @@ const renderBoardCard = ({
   cardNumber?: string;
   onClick?: () => void;
 }) => {
-  document.cookie = `${TAP_TO_PREVIEW_PLAY_COOKIE}=${cookieEnabled ? 'true' : 'false'}; path=/`;
+  document.cookie = `${TAP_TO_PREVIEW_PLAY_COOKIE}=${
+    cookieEnabled ? 'true' : 'false'
+  }; path=/`;
   return renderWithProviders(
     <CookiesProvider>
       <CardPopUp cardNumber={cardNumber} onClick={onClick}>
@@ -64,7 +66,7 @@ describe('CardPopUp board tap to preview', () => {
       expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR076');
     });
     expect(onClick).not.toHaveBeenCalled();
-    expect(getTapToPreviewSelectedCardKey()).toBe('board:me:WTR076');
+    expect(getTapToPreviewSelectedCardKey()).toMatch(/^board:me:WTR076:/);
 
     fireEvent.mouseLeave(card);
     expect(store.getState().game.popup?.popupOn).toBe(true);
@@ -108,6 +110,41 @@ describe('CardPopUp board tap to preview', () => {
     });
     expect(onClickA).not.toHaveBeenCalled();
     expect(onClickB).not.toHaveBeenCalled();
+  });
+
+  it('two instances of the same cardNumber stay distinct (no false confirm)', async () => {
+    document.cookie = `${TAP_TO_PREVIEW_PLAY_COOKIE}=true; path=/`;
+    const onClickA = vi.fn();
+    const onClickB = vi.fn();
+    const { store } = renderWithProviders(
+      <CookiesProvider>
+        <CardPopUp cardNumber="WTR001" onClick={onClickA}>
+          <button type="button">dup-a</button>
+        </CardPopUp>
+        <CardPopUp cardNumber="WTR001" onClick={onClickB}>
+          <button type="button">dup-b</button>
+        </CardPopUp>
+      </CookiesProvider>
+    );
+
+    const cardA = screen.getByRole('button', { name: 'dup-a' });
+    const cardB = screen.getByRole('button', { name: 'dup-b' });
+    fireEvent.pointerDown(cardA, { pointerType: 'touch' });
+    fireEvent.click(cardA);
+    await waitFor(() => {
+      expect(store.getState().game.popup?.popupOn).toBe(true);
+    });
+    const keyAfterA = getTapToPreviewSelectedCardKey();
+    expect(keyAfterA).toMatch(/^board:me:WTR001:/);
+
+    fireEvent.pointerDown(cardB, { pointerType: 'touch' });
+    fireEvent.click(cardB);
+    await waitFor(() => {
+      expect(getTapToPreviewSelectedCardKey()).not.toBe(keyAfterA);
+    });
+    expect(onClickA).not.toHaveBeenCalled();
+    expect(onClickB).not.toHaveBeenCalled();
+    expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR001');
   });
 
   it('dismisses sticky board preview on outside tap', async () => {

--- a/src/routes/game/components/elements/cardPopUp/__tests__/CardPopUp.tapToPreview.test.tsx
+++ b/src/routes/game/components/elements/cardPopUp/__tests__/CardPopUp.tapToPreview.test.tsx
@@ -15,6 +15,11 @@ vi.mock('hooks/useLanguageSelector', () => ({
   })
 }));
 
+const tapCard = (el: HTMLElement) => {
+  fireEvent.pointerDown(el, { pointerType: 'touch' });
+  fireEvent.click(el);
+};
+
 const renderBoardCard = ({
   cookieEnabled,
   cardNumber = 'WTR076',
@@ -30,7 +35,7 @@ const renderBoardCard = ({
   return renderWithProviders(
     <CookiesProvider>
       <CardPopUp cardNumber={cardNumber} onClick={onClick}>
-        <button type="button">board-card</button>
+        <button type="button" data-testid="board-card" />
       </CardPopUp>
     </CookiesProvider>
   );
@@ -45,10 +50,7 @@ describe('CardPopUp board tap to preview', () => {
   it('fires onClick immediately when the option is off', () => {
     const onClick = vi.fn();
     const { store } = renderBoardCard({ cookieEnabled: false, onClick });
-    fireEvent.pointerDown(screen.getByRole('button', { name: 'board-card' }), {
-      pointerType: 'touch'
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'board-card' }));
+    tapCard(screen.getByTestId('board-card'));
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(store.getState().game.popup?.popupOn).not.toBe(true);
   });
@@ -56,10 +58,9 @@ describe('CardPopUp board tap to preview', () => {
   it('tap board card → sticky preview; second tap runs onClick', async () => {
     const onClick = vi.fn();
     const { store } = renderBoardCard({ cookieEnabled: true, onClick });
-    const card = screen.getByRole('button', { name: 'board-card' });
+    const card = screen.getByTestId('board-card');
 
-    fireEvent.pointerDown(card, { pointerType: 'touch' });
-    fireEvent.click(card);
+    tapCard(card);
 
     await waitFor(() => {
       expect(store.getState().game.popup?.popupOn).toBe(true);
@@ -71,8 +72,7 @@ describe('CardPopUp board tap to preview', () => {
     fireEvent.mouseLeave(card);
     expect(store.getState().game.popup?.popupOn).toBe(true);
 
-    fireEvent.pointerDown(card, { pointerType: 'touch' });
-    fireEvent.click(card);
+    tapCard(card);
 
     await waitFor(() => {
       expect(onClick).toHaveBeenCalledTimes(1);
@@ -87,24 +87,22 @@ describe('CardPopUp board tap to preview', () => {
     const { store } = renderWithProviders(
       <CookiesProvider>
         <CardPopUp cardNumber="WTR001" onClick={onClickA}>
-          <button type="button">card-a</button>
+          <button type="button" data-testid="card-a" />
         </CardPopUp>
         <CardPopUp cardNumber="WTR002" onClick={onClickB}>
-          <button type="button">card-b</button>
+          <button type="button" data-testid="card-b" />
         </CardPopUp>
       </CookiesProvider>
     );
 
-    const cardA = screen.getByRole('button', { name: 'card-a' });
-    const cardB = screen.getByRole('button', { name: 'card-b' });
-    fireEvent.pointerDown(cardA, { pointerType: 'touch' });
-    fireEvent.click(cardA);
+    const cardA = screen.getByTestId('card-a');
+    const cardB = screen.getByTestId('card-b');
+    tapCard(cardA);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR001');
     });
 
-    fireEvent.pointerDown(cardB, { pointerType: 'touch' });
-    fireEvent.click(cardB);
+    tapCard(cardB);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR002');
     });
@@ -119,26 +117,24 @@ describe('CardPopUp board tap to preview', () => {
     const { store } = renderWithProviders(
       <CookiesProvider>
         <CardPopUp cardNumber="WTR001" onClick={onClickA}>
-          <button type="button">dup-a</button>
+          <button type="button" data-testid="dup-a" />
         </CardPopUp>
         <CardPopUp cardNumber="WTR001" onClick={onClickB}>
-          <button type="button">dup-b</button>
+          <button type="button" data-testid="dup-b" />
         </CardPopUp>
       </CookiesProvider>
     );
 
-    const cardA = screen.getByRole('button', { name: 'dup-a' });
-    const cardB = screen.getByRole('button', { name: 'dup-b' });
-    fireEvent.pointerDown(cardA, { pointerType: 'touch' });
-    fireEvent.click(cardA);
+    const cardA = screen.getByTestId('dup-a');
+    const cardB = screen.getByTestId('dup-b');
+    tapCard(cardA);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupOn).toBe(true);
     });
     const keyAfterA = getTapToPreviewSelectedCardKey();
     expect(keyAfterA).toMatch(/^board:me:WTR001:/);
 
-    fireEvent.pointerDown(cardB, { pointerType: 'touch' });
-    fireEvent.click(cardB);
+    tapCard(cardB);
     await waitFor(() => {
       expect(getTapToPreviewSelectedCardKey()).not.toBe(keyAfterA);
     });
@@ -150,9 +146,8 @@ describe('CardPopUp board tap to preview', () => {
   it('dismisses sticky board preview on outside tap', async () => {
     const onClick = vi.fn();
     const { store } = renderBoardCard({ cookieEnabled: true, onClick });
-    const card = screen.getByRole('button', { name: 'board-card' });
-    fireEvent.pointerDown(card, { pointerType: 'touch' });
-    fireEvent.click(card);
+    const card = screen.getByTestId('board-card');
+    tapCard(card);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupOn).toBe(true);
     });
@@ -173,15 +168,14 @@ describe('CardPopUp board tap to preview', () => {
       <CookiesProvider>
         <div onClick={parentClick}>
           <CardPopUp cardNumber="WTR076" onClick={cardClick}>
-            <button type="button">zone-card</button>
+            <button type="button" data-testid="zone-card" />
           </CardPopUp>
         </div>
       </CookiesProvider>
     );
 
-    const card = screen.getByRole('button', { name: 'zone-card' });
-    fireEvent.pointerDown(card, { pointerType: 'touch' });
-    fireEvent.click(card);
+    const card = screen.getByTestId('zone-card');
+    tapCard(card);
 
     await waitFor(() => {
       expect(store.getState().game.popup?.popupOn).toBe(true);
@@ -196,24 +190,22 @@ describe('CardPopUp board tap to preview', () => {
     const { store } = renderWithProviders(
       <CookiesProvider>
         <CardPopUp cardNumber="WTR001" onClick={onClickA}>
-          <button type="button">playable</button>
+          <button type="button" data-testid="playable" />
         </CardPopUp>
         <CardPopUp cardNumber="WTR002">
-          <button type="button">effect</button>
+          <button type="button" data-testid="effect" />
         </CardPopUp>
       </CookiesProvider>
     );
 
-    const playable = screen.getByRole('button', { name: 'playable' });
-    const effect = screen.getByRole('button', { name: 'effect' });
-    fireEvent.pointerDown(playable, { pointerType: 'touch' });
-    fireEvent.click(playable);
+    const playable = screen.getByTestId('playable');
+    const effect = screen.getByTestId('effect');
+    tapCard(playable);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR001');
     });
 
-    fireEvent.pointerDown(effect, { pointerType: 'touch' });
-    fireEvent.click(effect);
+    tapCard(effect);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR002');
     });

--- a/src/routes/game/components/elements/cardPopUp/__tests__/CardPopUp.tapToPreview.test.tsx
+++ b/src/routes/game/components/elements/cardPopUp/__tests__/CardPopUp.tapToPreview.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { CookiesProvider } from 'react-cookie';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderWithProviders } from 'utils/TestUtils';
+import CardPopUp from '../CardPopUp';
+import {
+  TAP_TO_PREVIEW_PLAY_COOKIE,
+  clearTapToPreviewSelection,
+  getTapToPreviewSelectedCardKey
+} from '../../playerHandCard/tapToPreviewPlay';
+
+vi.mock('hooks/useLanguageSelector', () => ({
+  useLanguageSelector: () => ({
+    getLanguage: () => 'english'
+  })
+}));
+
+const renderBoardCard = ({
+  cookieEnabled,
+  cardNumber = 'WTR076',
+  onClick
+}: {
+  cookieEnabled: boolean;
+  cardNumber?: string;
+  onClick?: () => void;
+}) => {
+  document.cookie = `${TAP_TO_PREVIEW_PLAY_COOKIE}=${cookieEnabled ? 'true' : 'false'}; path=/`;
+  return renderWithProviders(
+    <CookiesProvider>
+      <CardPopUp cardNumber={cardNumber} onClick={onClick}>
+        <button type="button">board-card</button>
+      </CardPopUp>
+    </CookiesProvider>
+  );
+};
+
+describe('CardPopUp board tap to preview', () => {
+  beforeEach(() => {
+    clearTapToPreviewSelection();
+    document.cookie = `${TAP_TO_PREVIEW_PLAY_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+  });
+
+  it('fires onClick immediately when the option is off', () => {
+    const onClick = vi.fn();
+    const { store } = renderBoardCard({ cookieEnabled: false, onClick });
+    fireEvent.click(screen.getByRole('button', { name: 'board-card' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(store.getState().game.popup?.popupOn).not.toBe(true);
+  });
+
+  it('tap board card → sticky preview; second tap runs onClick', async () => {
+    const onClick = vi.fn();
+    const { store } = renderBoardCard({ cookieEnabled: true, onClick });
+    const card = screen.getByRole('button', { name: 'board-card' });
+
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      expect(store.getState().game.popup?.popupOn).toBe(true);
+      expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR076');
+    });
+    expect(onClick).not.toHaveBeenCalled();
+    expect(getTapToPreviewSelectedCardKey()).toBe('board:me:WTR076');
+
+    fireEvent.mouseLeave(card);
+    expect(store.getState().game.popup?.popupOn).toBe(true);
+
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+    expect(getTapToPreviewSelectedCardKey()).toBeNull();
+  });
+
+  it('tap A then tap B switches board preview without activating A', async () => {
+    document.cookie = `${TAP_TO_PREVIEW_PLAY_COOKIE}=true; path=/`;
+    const onClickA = vi.fn();
+    const onClickB = vi.fn();
+    const { store } = renderWithProviders(
+      <CookiesProvider>
+        <CardPopUp cardNumber="WTR001" onClick={onClickA}>
+          <button type="button">card-a</button>
+        </CardPopUp>
+        <CardPopUp cardNumber="WTR002" onClick={onClickB}>
+          <button type="button">card-b</button>
+        </CardPopUp>
+      </CookiesProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'card-a' }));
+    await waitFor(() => {
+      expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR001');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'card-b' }));
+    await waitFor(() => {
+      expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR002');
+    });
+    expect(onClickA).not.toHaveBeenCalled();
+    expect(onClickB).not.toHaveBeenCalled();
+  });
+
+  it('dismisses sticky board preview on outside tap', async () => {
+    const onClick = vi.fn();
+    const { store } = renderBoardCard({ cookieEnabled: true, onClick });
+    fireEvent.click(screen.getByRole('button', { name: 'board-card' }));
+    await waitFor(() => {
+      expect(store.getState().game.popup?.popupOn).toBe(true);
+    });
+
+    fireEvent.pointerDown(document.body);
+    await waitFor(() => {
+      expect(store.getState().game.popup?.popupOn).not.toBe(true);
+    });
+    expect(onClick).not.toHaveBeenCalled();
+    expect(getTapToPreviewSelectedCardKey()).toBeNull();
+  });
+});

--- a/src/routes/game/components/elements/cardPopUp/__tests__/CardPopUp.tapToPreview.test.tsx
+++ b/src/routes/game/components/elements/cardPopUp/__tests__/CardPopUp.tapToPreview.test.tsx
@@ -164,4 +164,59 @@ describe('CardPopUp board tap to preview', () => {
     expect(onClick).not.toHaveBeenCalled();
     expect(getTapToPreviewSelectedCardKey()).toBeNull();
   });
+
+  it('does not stopPropagation so parent click handlers still run', async () => {
+    document.cookie = `${TAP_TO_PREVIEW_PLAY_COOKIE}=true; path=/`;
+    const parentClick = vi.fn();
+    const cardClick = vi.fn();
+    const { store } = renderWithProviders(
+      <CookiesProvider>
+        <div onClick={parentClick}>
+          <CardPopUp cardNumber="WTR076" onClick={cardClick}>
+            <button type="button">zone-card</button>
+          </CardPopUp>
+        </div>
+      </CookiesProvider>
+    );
+
+    const card = screen.getByRole('button', { name: 'zone-card' });
+    fireEvent.pointerDown(card, { pointerType: 'touch' });
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      expect(store.getState().game.popup?.popupOn).toBe(true);
+    });
+    expect(cardClick).not.toHaveBeenCalled();
+    expect(parentClick).toHaveBeenCalled();
+  });
+
+  it('tapping a non-play CardPopUp dismisses then previews that card', async () => {
+    document.cookie = `${TAP_TO_PREVIEW_PLAY_COOKIE}=true; path=/`;
+    const onClickA = vi.fn();
+    const { store } = renderWithProviders(
+      <CookiesProvider>
+        <CardPopUp cardNumber="WTR001" onClick={onClickA}>
+          <button type="button">playable</button>
+        </CardPopUp>
+        <CardPopUp cardNumber="WTR002">
+          <button type="button">effect</button>
+        </CardPopUp>
+      </CookiesProvider>
+    );
+
+    const playable = screen.getByRole('button', { name: 'playable' });
+    const effect = screen.getByRole('button', { name: 'effect' });
+    fireEvent.pointerDown(playable, { pointerType: 'touch' });
+    fireEvent.click(playable);
+    await waitFor(() => {
+      expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR001');
+    });
+
+    fireEvent.pointerDown(effect, { pointerType: 'touch' });
+    fireEvent.click(effect);
+    await waitFor(() => {
+      expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR002');
+    });
+    expect(onClickA).not.toHaveBeenCalled();
+  });
 });

--- a/src/routes/game/components/elements/playerHandCard/PlayerHandCard.tsx
+++ b/src/routes/game/components/elements/playerHandCard/PlayerHandCard.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useRef, useState, useMemo } from 'react';
+import React, { useRef, useState, useMemo } from 'react';
 import {
   clearPopUp,
   playCard,
-  removeCardFromHand,
-  setPopUp
+  removeCardFromHand
 } from 'features/game/GameSlice';
 import {
   GiTombstone,
@@ -13,8 +12,7 @@ import {
 } from 'react-icons/gi';
 import { Card } from 'features/Card';
 import styles from './PlayerHandCard.module.css';
-import { useAppDispatch, useAppSelector } from 'app/Hooks';
-import { RootState } from 'app/Store';
+import { useAppDispatch } from 'app/Hooks';
 import { LONG_PRESS_TIMER } from 'appConstants';
 import classNames from 'classnames';
 import CardImage from '../cardImage/CardImage';
@@ -29,17 +27,10 @@ import { createPortal } from 'react-dom';
 import { CARD_SQUARES_PATH, getCollectionCardImagePath } from 'utils';
 import { useLanguageSelector } from 'hooks/useLanguageSelector';
 import { formatRestriction } from 'data/keywords';
-import { useCookies } from 'react-cookie';
 import {
-  TAP_PREVIEW_CARD_SELECTOR,
-  TAP_TO_PREVIEW_PLAY_COOKIE,
   buildHandCardSelectionKey,
   clearTapToPreviewSelection,
-  getTapToPreviewSelectedCardKey,
-  isTapToPreviewPlayEnabled,
-  resolveTapToPreviewPlay,
-  setTapToPreviewSelectedCardKey,
-  shouldDismissStickyPreviewOnOutsideTap
+  getTapToPreviewSelectedCardKey
 } from './tapToPreviewPlay';
 
 const ScreenPercentageForCardPlayed = 0.25;
@@ -95,7 +86,6 @@ export const PlayerHandCard = React.memo(
     const [isDragging, setIsDragging] = useState(false);
     const [snapback, setSnapback] = useState<boolean>(true);
     const { getLanguage } = useLanguageSelector();
-    const [cookies] = useCookies([TAP_TO_PREVIEW_PLAY_COOKIE]);
 
     // ref to determine if we have a long press or a short tap.
     const timerRef = useRef<ReturnType<typeof setTimeout>>();
@@ -119,72 +109,50 @@ export const PlayerHandCard = React.memo(
     const dragX = useMotionValue(0);
     const dragY = useMotionValue(0);
     const dispatch = useAppDispatch();
-    const popupCardNumber = useAppSelector(
-      (state: RootState) => state.game.popup?.popupCard?.cardNumber
-    );
 
-    const selectionKey = card
-      ? buildHandCardSelectionKey({
-          cardId,
-          cardNumber: card.cardNumber,
-          cardIndex: card.cardIndex,
-          zone: isArsenal
-            ? 'arsenal'
-            : isBanished
-              ? 'banished'
-              : isGraveyard
-                ? 'graveyard'
-                : 'hand'
-        })
-      : null;
-
-    // Dismiss sticky preview when tapping outside the hand (not on another hand card).
-    useEffect(() => {
-      const tapToPreviewEnabled = isTapToPreviewPlayEnabled(
-        cookies[TAP_TO_PREVIEW_PLAY_COOKIE]
-      );
-      if (
-        !tapToPreviewEnabled ||
-        !selectionKey ||
-        getTapToPreviewSelectedCardKey() !== selectionKey
-      ) {
-        return;
-      }
-
-      const onPointerDown = (event: PointerEvent) => {
-        const target = event.target as Element | null;
-        if (cardElRef.current?.contains(target)) {
-          return;
-        }
-        const isTapOnPreviewableCard = Boolean(
-          target?.closest?.(TAP_PREVIEW_CARD_SELECTOR)
-        );
-        if (
-          !shouldDismissStickyPreviewOnOutsideTap({
-            enabled: true,
-            selectedKey: getTapToPreviewSelectedCardKey(),
-            isTapOnPreviewableCard
-          })
-        ) {
-          return;
-        }
-        clearTapToPreviewSelection();
-        dispatch(clearPopUp());
-      };
-
-      document.addEventListener('pointerdown', onPointerDown);
-      return () => document.removeEventListener('pointerdown', onPointerDown);
-    }, [cookies, selectionKey, dispatch, popupCardNumber]);
-
-    if (card === undefined || selectionKey == null) {
+    if (card === undefined) {
       return <div className={styles.handCard}></div>;
     }
+
+    const selectionKey = buildHandCardSelectionKey({
+      cardId,
+      cardNumber: card.cardNumber,
+      cardIndex: card.cardIndex,
+      zone: isArsenal
+        ? 'arsenal'
+        : isBanished
+          ? 'banished'
+          : isGraveyard
+            ? 'graveyard'
+            : 'hand'
+    });
 
     const src = getCollectionCardImagePath({
       path: CARD_SQUARES_PATH,
       locale: getLanguage(),
       cardNumber: card.cardNumber
     });
+
+    const playCardFunc = () => {
+      clearTapToPreviewSelection();
+      dispatch(playCard({ cardParams: card }));
+      dispatch(clearPopUp());
+      if (!isBanished && !isGraveyard && !isArsenal) {
+        dispatch(removeCardFromHand({ card }));
+      }
+    };
+
+    const handlePlayFromTap = () => {
+      if (draggedRef.current) {
+        draggedRef.current = false;
+        return;
+      }
+      if (scrollBlockedRef?.current) return;
+      if (isLongPress.current) return;
+      if (!card.action) return;
+      playCardFunc();
+      addCardToPlayedCards(card.cardNumber);
+    };
 
     const handleDragStart = () => {
       const rect = cardElRef.current?.getBoundingClientRect();
@@ -256,32 +224,6 @@ export const PlayerHandCard = React.memo(
       onRotationHoldEnd?.();
     };
 
-    const playCardFunc = () => {
-      clearTapToPreviewSelection();
-      dispatch(playCard({ cardParams: card }));
-      dispatch(clearPopUp());
-      if (!isBanished && !isGraveyard && !isArsenal) {
-        dispatch(removeCardFromHand({ card }));
-      }
-    };
-
-    const showStickyPreview = () => {
-      const rect = cardElRef.current?.getBoundingClientRect();
-      if (!rect) {
-        dispatch(setPopUp({ cardNumber: card.cardNumber }));
-        return;
-      }
-      const xCoord = rect.left < window.innerWidth / 2 ? rect.right : rect.left;
-      const yCoord = rect.top < window.innerHeight / 2 ? rect.bottom : rect.top;
-      dispatch(
-        setPopUp({
-          cardNumber: card.cardNumber,
-          xCoord,
-          yCoord
-        })
-      );
-    };
-
     const onDrag = (
       event: MouseEvent | TouchEvent | PointerEvent,
       info: PanInfo
@@ -295,50 +237,13 @@ export const PlayerHandCard = React.memo(
       if (canPopUp && !hasDispatchedClearRef.current) {
         setSnapback(true);
         if (!isLongPress.current) {
-          // Keep sticky tap-to-preview portal visible while this card is selected.
-          const stickyPreview =
-            isTapToPreviewPlayEnabled(cookies[TAP_TO_PREVIEW_PLAY_COOKIE]) &&
-            getTapToPreviewSelectedCardKey() === selectionKey;
-          if (!stickyPreview) {
+          // Keep sticky preview while this hand card is selected.
+          if (getTapToPreviewSelectedCardKey() !== selectionKey) {
             dispatch(clearPopUp());
           }
           hasDispatchedClearRef.current = true;
           setCanPopup(false);
         }
-      }
-    };
-
-    const handleOnClick = () => {
-      if (draggedRef.current) {
-        draggedRef.current = false;
-        return;
-      }
-
-      if (scrollBlockedRef?.current) return;
-
-      // Tap to play card (unless it was a long press which shows preview)
-      if (!isLongPress.current) {
-        const isTouchLike =
-          lastPointerTypeRef.current === 'touch' || !supportsHover;
-        const tapToPreviewEnabled =
-          isTapToPreviewPlayEnabled(cookies[TAP_TO_PREVIEW_PLAY_COOKIE]) &&
-          isTouchLike;
-
-        if (tapToPreviewEnabled) {
-          const { action, nextSelectedKey } = resolveTapToPreviewPlay({
-            enabled: true,
-            cardKey: selectionKey
-          });
-          setTapToPreviewSelectedCardKey(nextSelectedKey);
-          if (action === 'preview') {
-            showStickyPreview();
-            return;
-          }
-        }
-
-        if (!card.action) return;
-        playCardFunc();
-        addCardToPlayedCards(card.cardNumber);
       }
     };
 
@@ -415,8 +320,6 @@ export const PlayerHandCard = React.memo(
       <>
         <motion.div
           ref={cardElRef}
-          data-hand-card="true"
-          data-tap-preview-card="true"
           data-is-dragging={isDragging}
           title="Hold and use the mouse wheel or Q/E for fine rotation. Right-click rotates 90°; Shift+right-click reverses it."
           layout={enableLayoutAnimation && !isDragging ? 'position' : false}
@@ -449,7 +352,6 @@ export const PlayerHandCard = React.memo(
                 }
               : {})
           }}
-          onClick={handleOnClick}
           onContextMenu={handleContextMenu}
           onTapStart={startPressTimer}
           onTap={stopPressTimer}
@@ -481,11 +383,8 @@ export const PlayerHandCard = React.memo(
             isHidden={!canPopUp}
             disableTilt={isDragging}
             disableShadow
-            suppressTapToPreview
-            persistPopUpOnClick={
-              isTapToPreviewPlayEnabled(cookies[TAP_TO_PREVIEW_PLAY_COOKIE]) &&
-              !supportsHover
-            }
+            tapPreviewKey={selectionKey}
+            onClick={handlePlayFromTap}
           >
             <CardImage src={src} className={imgStyles} draggable="false" />
             {iconColumn}

--- a/src/routes/game/components/elements/playerHandCard/PlayerHandCard.tsx
+++ b/src/routes/game/components/elements/playerHandCard/PlayerHandCard.tsx
@@ -31,6 +31,7 @@ import { useLanguageSelector } from 'hooks/useLanguageSelector';
 import { formatRestriction } from 'data/keywords';
 import { useCookies } from 'react-cookie';
 import {
+  TAP_PREVIEW_CARD_SELECTOR,
   TAP_TO_PREVIEW_PLAY_COOKIE,
   buildHandCardSelectionKey,
   clearTapToPreviewSelection,
@@ -155,14 +156,14 @@ export const PlayerHandCard = React.memo(
         if (cardElRef.current?.contains(target)) {
           return;
         }
-        const isTapOnHandCard = Boolean(
-          target?.closest?.('[data-hand-card="true"]')
+        const isTapOnPreviewableCard = Boolean(
+          target?.closest?.(TAP_PREVIEW_CARD_SELECTOR)
         );
         if (
           !shouldDismissStickyPreviewOnOutsideTap({
             enabled: true,
             selectedKey: getTapToPreviewSelectedCardKey(),
-            isTapOnHandCard
+            isTapOnPreviewableCard
           })
         ) {
           return;
@@ -415,6 +416,7 @@ export const PlayerHandCard = React.memo(
         <motion.div
           ref={cardElRef}
           data-hand-card="true"
+          data-tap-preview-card="true"
           data-is-dragging={isDragging}
           title="Hold and use the mouse wheel or Q/E for fine rotation. Right-click rotates 90°; Shift+right-click reverses it."
           layout={enableLayoutAnimation && !isDragging ? 'position' : false}
@@ -479,6 +481,7 @@ export const PlayerHandCard = React.memo(
             isHidden={!canPopUp}
             disableTilt={isDragging}
             disableShadow
+            suppressTapToPreview
             persistPopUpOnClick={
               isTapToPreviewPlayEnabled(cookies[TAP_TO_PREVIEW_PLAY_COOKIE]) &&
               !supportsHover

--- a/src/routes/game/components/elements/playerHandCard/__tests__/PlayerHandCard.tapToPreview.test.tsx
+++ b/src/routes/game/components/elements/playerHandCard/__tests__/PlayerHandCard.tapToPreview.test.tsx
@@ -58,7 +58,10 @@ const secondCard: Card = {
   actionDataOverride: '1'
 };
 
-const cardSelector = /Hold and use the mouse wheel/;
+const tapCard = (el: HTMLElement) => {
+  fireEvent.pointerDown(el, { pointerType: 'touch' });
+  fireEvent.click(el);
+};
 
 const renderHandCard = (cookieEnabled: boolean) => {
   document.cookie = `${TAP_TO_PREVIEW_PLAY_COOKIE}=${cookieEnabled ? 'true' : 'false'}; path=/`;
@@ -106,10 +109,7 @@ describe('PlayerHandCard tap to preview play', () => {
 
   it('plays immediately on tap when the option is disabled', async () => {
     const { store, addCardToPlayedCards } = renderHandCard(false);
-    const cardEl = screen.getByTitle(cardSelector);
-
-    fireEvent.pointerDown(cardEl, { pointerType: 'touch' });
-    fireEvent.click(cardEl);
+    tapCard(screen.getByTestId('card-image'));
 
     await waitFor(() => {
       expect(addCardToPlayedCards).toHaveBeenCalledWith('WTR001');
@@ -119,10 +119,9 @@ describe('PlayerHandCard tap to preview play', () => {
 
   it('tap A → preview A; tap A again → play A', async () => {
     const { store, addCardToPlayedCards } = renderHandCard(true);
-    const cardEl = screen.getByTitle(cardSelector);
+    const cardImg = screen.getByTestId('card-image');
 
-    fireEvent.pointerDown(cardEl, { pointerType: 'touch' });
-    fireEvent.click(cardEl);
+    tapCard(cardImg);
 
     await waitFor(() => {
       expect(store.getState().game.popup?.popupOn).toBe(true);
@@ -131,12 +130,10 @@ describe('PlayerHandCard tap to preview play', () => {
     expect(addCardToPlayedCards).not.toHaveBeenCalled();
     expect(getTapToPreviewSelectedCardKey()).toBe('id:hand-1');
 
-    // Touch browsers synthesize mouseleave after tap; sticky preview must remain.
-    fireEvent.mouseLeave(cardEl);
+    fireEvent.mouseLeave(cardImg);
     expect(store.getState().game.popup?.popupOn).toBe(true);
 
-    fireEvent.pointerDown(cardEl, { pointerType: 'touch' });
-    fireEvent.click(cardEl);
+    tapCard(cardImg);
 
     await waitFor(() => {
       expect(addCardToPlayedCards).toHaveBeenCalledWith('WTR001');
@@ -146,18 +143,14 @@ describe('PlayerHandCard tap to preview play', () => {
 
   it('tap A → preview A; tap B → preview B (does not play)', async () => {
     const { store, addCardToPlayedCards } = renderTwoHandCards();
-    const cards = screen.getAllByTitle(cardSelector);
+    const images = screen.getAllByTestId('card-image');
 
-    fireEvent.pointerDown(cards[0], { pointerType: 'touch' });
-    fireEvent.click(cards[0]);
-
+    tapCard(images[0]);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR001');
     });
 
-    fireEvent.pointerDown(cards[1], { pointerType: 'touch' });
-    fireEvent.click(cards[1]);
-
+    tapCard(images[1]);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR002');
     });
@@ -167,10 +160,7 @@ describe('PlayerHandCard tap to preview play', () => {
 
   it('dismisses sticky preview when tapping outside the hand', async () => {
     const { store, addCardToPlayedCards } = renderHandCard(true);
-    const cardEl = screen.getByTitle(cardSelector);
-
-    fireEvent.pointerDown(cardEl, { pointerType: 'touch' });
-    fireEvent.click(cardEl);
+    tapCard(screen.getByTestId('card-image'));
 
     await waitFor(() => {
       expect(store.getState().game.popup?.popupOn).toBe(true);
@@ -188,10 +178,9 @@ describe('PlayerHandCard tap to preview play', () => {
 
   it('after outside dismiss, tapping A again previews instead of playing', async () => {
     const { store, addCardToPlayedCards } = renderHandCard(true);
-    const cardEl = screen.getByTitle(cardSelector);
+    const cardImg = screen.getByTestId('card-image');
 
-    fireEvent.pointerDown(cardEl, { pointerType: 'touch' });
-    fireEvent.click(cardEl);
+    tapCard(cardImg);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupOn).toBe(true);
     });
@@ -201,9 +190,7 @@ describe('PlayerHandCard tap to preview play', () => {
       expect(store.getState().game.popup?.popupOn).not.toBe(true);
     });
 
-    fireEvent.pointerDown(cardEl, { pointerType: 'touch' });
-    fireEvent.click(cardEl);
-
+    tapCard(cardImg);
     await waitFor(() => {
       expect(store.getState().game.popup?.popupOn).toBe(true);
       expect(store.getState().game.popup?.popupCard?.cardNumber).toBe('WTR001');

--- a/src/routes/game/components/elements/playerHandCard/__tests__/tapToPreviewPlay.test.ts
+++ b/src/routes/game/components/elements/playerHandCard/__tests__/tapToPreviewPlay.test.ts
@@ -7,7 +7,8 @@ import {
   isTapToPreviewPlayEnabled,
   resolveTapToPreviewPlay,
   setTapToPreviewSelectedCardKey,
-  shouldDismissStickyPreviewOnOutsideTap
+  shouldDismissStickyPreviewOnOutsideTap,
+  subscribeTapToPreviewSelection
 } from '../tapToPreviewPlay';
 
 describe('tapToPreviewPlay', () => {
@@ -86,10 +87,13 @@ describe('tapToPreviewPlay', () => {
       expect(
         resolveTapToPreviewPlay({
           enabled: true,
-          cardKey: 'board:me:WTR001',
+          cardKey: 'board:me:WTR001::r1:',
           selectedKey: 'id:hand-1'
         })
-      ).toEqual({ action: 'preview', nextSelectedKey: 'board:me:WTR001' });
+      ).toEqual({
+        action: 'preview',
+        nextSelectedKey: 'board:me:WTR001::r1:'
+      });
     });
   });
 
@@ -141,6 +145,19 @@ describe('tapToPreviewPlay', () => {
       expect(getTapToPreviewSelectedCardKey()).toBeNull();
     });
 
+    it('notifies subscribers when selection changes', () => {
+      let calls = 0;
+      const unsubscribe = subscribeTapToPreviewSelection(() => {
+        calls += 1;
+      });
+      setTapToPreviewSelectedCardKey('id:card-a');
+      setTapToPreviewSelectedCardKey('id:card-a'); // no-op
+      clearTapToPreviewSelection();
+      unsubscribe();
+      setTapToPreviewSelectedCardKey('id:card-b');
+      expect(calls).toBe(2);
+    });
+
     it('uses module selection when selectedKey is omitted', () => {
       setTapToPreviewSelectedCardKey('id:card-a');
       expect(
@@ -172,13 +189,33 @@ describe('tapToPreviewPlay', () => {
   });
 
   describe('buildBoardCardSelectionKey', () => {
-    it('builds a stable board key', () => {
+    it('builds a per-instance board key', () => {
       expect(
-        buildBoardCardSelectionKey({ cardNumber: 'WTR001', isOpponent: false })
-      ).toBe('board:me:WTR001');
+        buildBoardCardSelectionKey({
+          cardNumber: 'WTR001',
+          isOpponent: false,
+          instanceId: ':r1:'
+        })
+      ).toBe('board:me:WTR001::r1:');
       expect(
-        buildBoardCardSelectionKey({ cardNumber: 'WTR001', isOpponent: true })
-      ).toBe('board:opp:WTR001');
+        buildBoardCardSelectionKey({
+          cardNumber: 'WTR001',
+          isOpponent: true,
+          instanceId: ':r2:'
+        })
+      ).toBe('board:opp:WTR001::r2:');
+    });
+
+    it('keeps duplicate cardNumbers distinct via instanceId', () => {
+      const a = buildBoardCardSelectionKey({
+        cardNumber: 'WTR001',
+        instanceId: ':a:'
+      });
+      const b = buildBoardCardSelectionKey({
+        cardNumber: 'WTR001',
+        instanceId: ':b:'
+      });
+      expect(a).not.toBe(b);
     });
   });
 });

--- a/src/routes/game/components/elements/playerHandCard/__tests__/tapToPreviewPlay.test.ts
+++ b/src/routes/game/components/elements/playerHandCard/__tests__/tapToPreviewPlay.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
+  buildBoardCardSelectionKey,
   buildHandCardSelectionKey,
   clearTapToPreviewSelection,
   getTapToPreviewSelectedCardKey,
@@ -80,25 +81,35 @@ describe('tapToPreviewPlay', () => {
         })
       ).toEqual({ action: 'preview', nextSelectedKey: 'id:card-a' });
     });
+
+    it('shares selection between hand and board keys', () => {
+      expect(
+        resolveTapToPreviewPlay({
+          enabled: true,
+          cardKey: 'board:me:WTR001',
+          selectedKey: 'id:hand-1'
+        })
+      ).toEqual({ action: 'preview', nextSelectedKey: 'board:me:WTR001' });
+    });
   });
 
   describe('shouldDismissStickyPreviewOnOutsideTap', () => {
-    it('dismisses when preview is active and tap is outside hand cards', () => {
+    it('dismisses when preview is active and tap is outside previewable cards', () => {
       expect(
         shouldDismissStickyPreviewOnOutsideTap({
           enabled: true,
           selectedKey: 'id:card-a',
-          isTapOnHandCard: false
+          isTapOnPreviewableCard: false
         })
       ).toBe(true);
     });
 
-    it('does not dismiss when tapping another hand card', () => {
+    it('does not dismiss when tapping another previewable card', () => {
       expect(
         shouldDismissStickyPreviewOnOutsideTap({
           enabled: true,
           selectedKey: 'id:card-a',
-          isTapOnHandCard: true
+          isTapOnPreviewableCard: true
         })
       ).toBe(false);
     });
@@ -108,14 +119,14 @@ describe('tapToPreviewPlay', () => {
         shouldDismissStickyPreviewOnOutsideTap({
           enabled: false,
           selectedKey: 'id:card-a',
-          isTapOnHandCard: false
+          isTapOnPreviewableCard: false
         })
       ).toBe(false);
       expect(
         shouldDismissStickyPreviewOnOutsideTap({
           enabled: true,
           selectedKey: null,
-          isTapOnHandCard: false
+          isTapOnPreviewableCard: false
         })
       ).toBe(false);
     });
@@ -157,6 +168,17 @@ describe('tapToPreviewPlay', () => {
           zone: 'arsenal'
         })
       ).toBe('arsenal:WTR001:2');
+    });
+  });
+
+  describe('buildBoardCardSelectionKey', () => {
+    it('builds a stable board key', () => {
+      expect(
+        buildBoardCardSelectionKey({ cardNumber: 'WTR001', isOpponent: false })
+      ).toBe('board:me:WTR001');
+      expect(
+        buildBoardCardSelectionKey({ cardNumber: 'WTR001', isOpponent: true })
+      ).toBe('board:opp:WTR001');
     });
   });
 });

--- a/src/routes/game/components/elements/playerHandCard/__tests__/tapToPreviewPlay.test.ts
+++ b/src/routes/game/components/elements/playerHandCard/__tests__/tapToPreviewPlay.test.ts
@@ -98,39 +98,26 @@ describe('tapToPreviewPlay', () => {
   });
 
   describe('shouldDismissStickyPreviewOnOutsideTap', () => {
-    it('dismisses when preview is active and tap is outside previewable cards', () => {
+    it('dismisses when preview is active', () => {
       expect(
         shouldDismissStickyPreviewOnOutsideTap({
           enabled: true,
-          selectedKey: 'id:card-a',
-          isTapOnPreviewableCard: false
+          selectedKey: 'id:card-a'
         })
       ).toBe(true);
-    });
-
-    it('does not dismiss when tapping another previewable card', () => {
-      expect(
-        shouldDismissStickyPreviewOnOutsideTap({
-          enabled: true,
-          selectedKey: 'id:card-a',
-          isTapOnPreviewableCard: true
-        })
-      ).toBe(false);
     });
 
     it('does not dismiss when option is off or nothing is selected', () => {
       expect(
         shouldDismissStickyPreviewOnOutsideTap({
           enabled: false,
-          selectedKey: 'id:card-a',
-          isTapOnPreviewableCard: false
+          selectedKey: 'id:card-a'
         })
       ).toBe(false);
       expect(
         shouldDismissStickyPreviewOnOutsideTap({
           enabled: true,
-          selectedKey: null,
-          isTapOnPreviewableCard: false
+          selectedKey: null
         })
       ).toBe(false);
     });

--- a/src/routes/game/components/elements/playerHandCard/tapToPreviewPlay.ts
+++ b/src/routes/game/components/elements/playerHandCard/tapToPreviewPlay.ts
@@ -1,29 +1,51 @@
 /** Cookie name for the client-only "tap to preview before playing" option. */
 export const TAP_TO_PREVIEW_PLAY_COOKIE = 'tapToPreviewPlay';
 
-/** Module-level selection so tapping a different hand card switches the preview. */
+/**
+ * Module-level sticky selection shared across CardPopUp instances (hand + board).
+ * Notified via subscribeTapToPreviewSelection so React can re-render with
+ * useSyncExternalStore — no Redux popup-card hack required.
+ */
 let selectedCardKey: string | null = null;
+const selectionListeners = new Set<() => void>();
 
 export function getTapToPreviewSelectedCardKey(): string | null {
   return selectedCardKey;
 }
 
+export function subscribeTapToPreviewSelection(
+  onStoreChange: () => void
+): () => void {
+  selectionListeners.add(onStoreChange);
+  return () => {
+    selectionListeners.delete(onStoreChange);
+  };
+}
+
+function notifyTapToPreviewSelectionListeners(): void {
+  selectionListeners.forEach((listener) => listener());
+}
+
 export function setTapToPreviewSelectedCardKey(cardKey: string | null): void {
+  if (selectedCardKey === cardKey) {
+    return;
+  }
   selectedCardKey = cardKey;
+  notifyTapToPreviewSelectionListeners();
 }
 
 export function clearTapToPreviewSelection(): void {
-  selectedCardKey = null;
+  setTapToPreviewSelectedCardKey(null);
 }
 
 export type TapToPreviewAction = 'preview' | 'play';
 
 /**
- * Resolves a hand-card tap when the tap-to-preview option is considered.
- * - Option off → always play (legacy one-tap behavior).
+ * Resolves a card tap when the tap-to-preview option is considered.
+ * - Option off → always play / activate (legacy one-tap behavior).
  * - Option on, first tap on a card → preview and remember selection.
- * - Option on, second tap on the same card → play and clear selection.
- * - Option on, tap on a different card → preview that card instead (do not play).
+ * - Option on, second tap on the same card → activate and clear selection.
+ * - Option on, tap on a different card → preview that card instead (do not activate).
  */
 export function resolveTapToPreviewPlay({
   enabled,
@@ -86,12 +108,15 @@ export function buildHandCardSelectionKey({
 
 export function buildBoardCardSelectionKey({
   cardNumber,
-  isOpponent
+  isOpponent,
+  instanceId
 }: {
   cardNumber: string;
   isOpponent?: boolean;
+  /** React useId (or other stable per-mount id) — required to distinguish duplicates. */
+  instanceId: string;
 }): string {
-  return `board:${isOpponent ? 'opp' : 'me'}:${cardNumber}`;
+  return `board:${isOpponent ? 'opp' : 'me'}:${cardNumber}:${instanceId}`;
 }
 
 export function isTapToPreviewPlayEnabled(

--- a/src/routes/game/components/elements/playerHandCard/tapToPreviewPlay.ts
+++ b/src/routes/game/components/elements/playerHandCard/tapToPreviewPlay.ts
@@ -68,26 +68,19 @@ export function resolveTapToPreviewPlay({
 }
 
 /**
- * Outside taps dismiss a sticky preview. Taps on another previewable card
- * (hand or board) are ignored here so that card can switch the preview itself.
+ * Outside taps dismiss a sticky preview. "Outside" is decided by the caller
+ * (tap not inside the sticky card's own element). Tapping another card clears
+ * here on pointerdown; that card's click then selects/previews itself.
  */
 export function shouldDismissStickyPreviewOnOutsideTap({
   enabled,
-  selectedKey,
-  isTapOnPreviewableCard
+  selectedKey
 }: {
   enabled: boolean;
   selectedKey: string | null;
-  isTapOnPreviewableCard: boolean;
 }): boolean {
-  if (!enabled || selectedKey == null || isTapOnPreviewableCard) {
-    return false;
-  }
-  return true;
+  return enabled && selectedKey != null;
 }
-
-/** CSS selector for cards that participate in tap-to-preview switching. */
-export const TAP_PREVIEW_CARD_SELECTOR = '[data-tap-preview-card="true"]';
 
 export function buildHandCardSelectionKey({
   cardId,

--- a/src/routes/game/components/elements/playerHandCard/tapToPreviewPlay.ts
+++ b/src/routes/game/components/elements/playerHandCard/tapToPreviewPlay.ts
@@ -46,23 +46,26 @@ export function resolveTapToPreviewPlay({
 }
 
 /**
- * Outside taps dismiss a sticky preview. Taps on another hand card are ignored
- * here so that card can switch the preview / confirm-play itself.
+ * Outside taps dismiss a sticky preview. Taps on another previewable card
+ * (hand or board) are ignored here so that card can switch the preview itself.
  */
 export function shouldDismissStickyPreviewOnOutsideTap({
   enabled,
   selectedKey,
-  isTapOnHandCard
+  isTapOnPreviewableCard
 }: {
   enabled: boolean;
   selectedKey: string | null;
-  isTapOnHandCard: boolean;
+  isTapOnPreviewableCard: boolean;
 }): boolean {
-  if (!enabled || selectedKey == null || isTapOnHandCard) {
+  if (!enabled || selectedKey == null || isTapOnPreviewableCard) {
     return false;
   }
   return true;
 }
+
+/** CSS selector for cards that participate in tap-to-preview switching. */
+export const TAP_PREVIEW_CARD_SELECTOR = '[data-tap-preview-card="true"]';
 
 export function buildHandCardSelectionKey({
   cardId,
@@ -79,6 +82,16 @@ export function buildHandCardSelectionKey({
     return `id:${cardId}`;
   }
   return `${zone}:${cardNumber}:${cardIndex ?? ''}`;
+}
+
+export function buildBoardCardSelectionKey({
+  cardNumber,
+  isOpponent
+}: {
+  cardNumber: string;
+  isOpponent?: boolean;
+}): string {
+  return `board:${isOpponent ? 'opp' : 'me'}:${cardNumber}`;
 }
 
 export function isTapToPreviewPlayEnabled(


### PR DESCRIPTION
Unifies tap-to-preview in CardPopUp for hand + board (equipment, effects, chain).

- First tap previews, second tap activates, outside tap dismisses
- Unique selection keys (no collision on duplicate cardNumbers)
- Keeps parent zone/modal click handlers working