### PR TITLE
Don't style player chat as a critical log event

### DIFF
--- a/src/routes/game/components/elements/chatBox/GameLogMessages.tsx
+++ b/src/routes/game/components/elements/chatBox/GameLogMessages.tsx
@@ -47,7 +47,7 @@ function importanceClass(message: string) {
   const text = plainText(message);
   if (PASS_RE.test(text) || MUTED_COMBAT_END_RE.test(text))
     return styles.logMuted;
-  if (DAMAGE_RE.test(text)) return styles.logCritical;
+  if (DAMAGE_RE.test(text) && !CHAT_RE.test(message)) return styles.logCritical;
   if (ACTION_RE.test(text)) return styles.logAction;
   if (IRREVERSIBLE_RE.test(text)) return styles.logIrreversible;
   return undefined;


### PR DESCRIPTION
Chat containing "won", "damage", "conceded" etc. matched `DAMAGE_RE` and rendered in the amber critical style reserved for system log lines. Skip that class for chat messages.
<img width="332" height="217" alt="image" src="https://github.com/user-attachments/assets/141ea4e0-8661-468a-a10c-e2808648d511" />
